### PR TITLE
Avoid setting Transfer-encoding chunked for all requests

### DIFF
--- a/src/main/java/io/vertx/httpproxy/impl/ProxyRequestImpl.java
+++ b/src/main/java/io/vertx/httpproxy/impl/ProxyRequestImpl.java
@@ -153,7 +153,8 @@ public class ProxyRequestImpl implements ProxyRequest {
     if (len >= 0) {
       inboundRequest.putHeader(HttpHeaders.CONTENT_LENGTH, Long.toString(len));
     } else {
-      inboundRequest.setChunked(true);
+      Boolean isChunked = HttpUtils.isChunked(outboundRequest.headers());
+      inboundRequest.setChunked(len == -1 && Boolean.TRUE == isChunked);
     }
 
     Pipe<Buffer> pipe = body.stream().pipe();

--- a/src/test/java/io/vertx/httpproxy/ProxyRequestTest.java
+++ b/src/test/java/io/vertx/httpproxy/ProxyRequestTest.java
@@ -68,7 +68,6 @@ public class ProxyRequestTest extends ProxyTestBase {
     testChunkedBackendResponse(ctx, HttpVersion.HTTP_1_1);
   }
 
-  @Ignore
   @Test
   public void testChunkedBackendResponseToHttp1_0Client(TestContext ctx) {
     testChunkedBackendResponse(ctx, HttpVersion.HTTP_1_0);
@@ -79,7 +78,13 @@ public class ProxyRequestTest extends ProxyTestBase {
     HttpClient httpClient = vertx.createHttpClient(new HttpClientOptions().setProtocolVersion(version));
     httpClient.request(HttpMethod.GET, 8080, "localhost", "/somepath")
         .compose(req -> req.send().compose(HttpClientResponse::body))
-        .onComplete(ctx.asyncAssertSuccess());
+        .onComplete(result -> {
+          if (version == HttpVersion.HTTP_1_0) {
+            ctx.assertFalse(result.succeeded());
+          } else {
+            ctx.assertTrue(result.succeeded());
+          }
+        });
   }
 
   @Ignore


### PR DESCRIPTION
The proxy implementation sets transfer-encoding: chunked on all HTTP methods. However, GET or HEAD (and probably some others) will almost never have a body. While it's AFAIK not strictly illegal to have a body in GET, it doesn't make sense, it causes issues with our backend (based on Hiawatha), and RFC 7231 sections 4.3 marks it as undefined behavior for GET, HEAD, DELETE and CONNECT (see #17).

This change modifies the proxy behavior so that `transfer-encoding: chunked` is only sent to the proxy backend/origin when the user agent requested chunked encoding.