### PR TITLE
We need to give users more source request control and enhance the application scenario of http proxy.

### DIFF
--- a/src/main/java/examples/HttpProxyExamples.java
+++ b/src/main/java/examples/HttpProxyExamples.java
@@ -6,6 +6,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.RequestOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.httpproxy.Body;
 import io.vertx.httpproxy.HttpProxy;
@@ -119,9 +120,12 @@ public class HttpProxyExamples {
   }
 
   public void more(Vertx vertx, HttpClient proxyClient) {
-    HttpProxy proxy = HttpProxy.reverseProxy(proxyClient).originSelector(
-      address -> Future.succeededFuture(SocketAddress.inetSocketAddress(7070, "origin"))
-    );
+      HttpProxy proxy = HttpProxy.reverseProxy(proxyClient).originSelector(req -> {
+          RequestOptions requestOptions = new RequestOptions();
+          requestOptions.setServer(SocketAddress.inetSocketAddress(443, "origin"));
+          requestOptions.setSsl(Boolean.TRUE).setTimeout(1000).putHeader("Host", "origin");
+          return Future.succeededFuture(requestOptions);
+      });
   }
 
   public void lowLevel(Vertx vertx, HttpServer proxyServer, HttpClient proxyClient) {

--- a/src/main/java/io/vertx/httpproxy/HttpProxy.java
+++ b/src/main/java/io/vertx/httpproxy/HttpProxy.java
@@ -11,12 +11,12 @@
 package io.vertx.httpproxy;
 
 import io.vertx.codegen.annotations.Fluent;
-import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.RequestOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.httpproxy.impl.ReverseProxy;
 
@@ -58,7 +58,7 @@ public interface HttpProxy extends Handler<HttpServerRequest> {
    */
   @Fluent
   default HttpProxy origin(SocketAddress address) {
-    return originSelector(req -> Future.succeededFuture(address));
+      return originSelector(req -> Future.succeededFuture(new RequestOptions().setServer(address)));
   }
 
   /**
@@ -74,13 +74,13 @@ public interface HttpProxy extends Handler<HttpServerRequest> {
   }
 
   /**
-   * Set a selector that resolves the <i><b>origin</b></i> address based on the <i><b>outbound</b></i> request.
+   * Set a selector that resolves the <i><b>origin</b></i> request based on the <i><b>outbound</b></i> request.
    *
    * @param selector the selector
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  HttpProxy originSelector(Function<HttpServerRequest, Future<SocketAddress>> selector);
+  HttpProxy originSelector(Function<HttpServerRequest, Future<RequestOptions>> selector);
 
   /**
    * Add an interceptor to the interceptor chain.

--- a/src/main/java/io/vertx/httpproxy/impl/ReverseProxy.java
+++ b/src/main/java/io/vertx/httpproxy/impl/ReverseProxy.java
@@ -22,7 +22,6 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.net.NetSocket;
-import io.vertx.core.net.SocketAddress;
 import io.vertx.httpproxy.HttpProxy;
 import io.vertx.httpproxy.ProxyContext;
 import io.vertx.httpproxy.ProxyInterceptor;
@@ -43,7 +42,7 @@ public class ReverseProxy implements HttpProxy {
 
   private final HttpClient client;
   private final boolean supportWebSocket;
-  private Function<HttpServerRequest, Future<SocketAddress>> selector = req -> Future.failedFuture("No origin available");
+  private Function<HttpServerRequest, Future<RequestOptions>> selector = req -> Future.failedFuture("No origin available");
   private final List<ProxyInterceptor> interceptors = new ArrayList<>();
 
   public ReverseProxy(ProxyOptions options, HttpClient client) {
@@ -57,7 +56,7 @@ public class ReverseProxy implements HttpProxy {
   }
 
   @Override
-  public HttpProxy originSelector(Function<HttpServerRequest, Future<SocketAddress>> selector) {
+  public HttpProxy originSelector(Function<HttpServerRequest, Future<RequestOptions>> selector) {
     this.selector = selector;
     return this;
   }
@@ -156,9 +155,7 @@ public class ReverseProxy implements HttpProxy {
   }
 
   private Future<HttpClientRequest> resolveOrigin(HttpServerRequest proxiedRequest) {
-    return selector.apply(proxiedRequest).flatMap(server -> {
-      RequestOptions requestOptions = new RequestOptions();
-      requestOptions.setServer(server);
+    return selector.apply(proxiedRequest).flatMap(requestOptions -> {
       return client.request(requestOptions);
     });
   }

--- a/src/test/java/io/vertx/httpproxy/ProxyTest.java
+++ b/src/test/java/io/vertx/httpproxy/ProxyTest.java
@@ -14,6 +14,7 @@ import io.vertx.core.Future;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -47,7 +48,8 @@ public class ProxyTest extends ProxyTestBase {
       backends[i] = startHttpBackend(ctx, 8081 + value, req -> req.response().end("" + value));
     }
     AtomicInteger count = new AtomicInteger();
-    startProxy(proxy -> proxy.originSelector(req -> Future.succeededFuture(backends[count.getAndIncrement() % backends.length])));
+    startProxy(proxy -> proxy.originSelector(req -> Future
+        .succeededFuture(new RequestOptions().setServer(backends[count.getAndIncrement() % backends.length]))));
     HttpClient client = vertx.createHttpClient();
     Map<String, AtomicInteger> result = Collections.synchronizedMap(new HashMap<>());
     Async latch = ctx.async();

--- a/src/test/java/io/vertx/httpproxy/TestBase.java
+++ b/src/test/java/io/vertx/httpproxy/TestBase.java
@@ -69,7 +69,7 @@ public abstract class TestBase {
   }
 
   protected Closeable startProxy(SocketAddress backend) {
-    return startProxy(proxy -> proxy.originSelector(req -> Future.succeededFuture(backend)));
+    return startProxy(proxy -> proxy.origin(backend));
   }
 
   protected Closeable startProxy(Consumer<HttpProxy> config) {


### PR DESCRIPTION
and other request options

Motivation:

We need to give users more source request control and enhance the application scenario of http proxy.  more https://github.com/eclipse-vertx/vertx-http-proxy/issues/37 

This is an example of a reverse proxy security site. Unfortunately, it cannot work properly because its connections are built on the TCP layer, not the TLS layer.
`
HttpProxy httpProxy = HttpProxy.reverseProxy(client) .originSelector(req -> Future.succeededFuture(SocketAddress.inetSocketAddress(443, "vertx.io")));
`

If more origin request options can be exposed, it can work normally。for example：
`
HttpProxy proxy = HttpProxy.reverseProxy(proxyClient).originSelector(req -> { 
	RequestOptions requestOptions = new RequestOptions(); 
	requestOptions.setServer(SocketAddress.inetSocketAddress(443, "origin")); 
	requestOptions.setSsl(Boolean.TRUE).setTimeout(1000).putHeader("Host", "origin"); 
	return Future.succeededFuture(requestOptions); 
});
`

Conformance:


You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
