### PR TITLE
HttProxy now accepts a request provider that is called whenever a request to the origin is created

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -46,6 +46,24 @@ You can create a *proxy server* that listens to port `8080` and implement revers
 
 All user-agent requests are forwarded to the *origin server* conveniently.
 
+=== Origin server routing
+
+You can create a proxy that forwards all the traffic to a single server like seen before
+
+You can set an origin selector to route the traffic to a given server
+
+[source,java]
+----
+{@link examples.HttpProxyExamples#originSelector}
+----
+
+You can set a function to create the client request to the origin server for ultimate flexibility
+
+[source,java]
+----
+{@link examples.HttpProxyExamples#originRequestProvider}
+----
+
 === WebSockets
 
 The proxy supports WebSocket by default.

--- a/src/main/java/examples/HttpProxyExamples.java
+++ b/src/main/java/examples/HttpProxyExamples.java
@@ -6,6 +6,8 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.RequestOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.httpproxy.Body;
 import io.vertx.httpproxy.HttpProxy;
@@ -41,6 +43,22 @@ public class HttpProxyExamples {
     HttpServer proxyServer = vertx.createHttpServer();
 
     proxyServer.requestHandler(proxy).listen(8080);
+  }
+
+  private SocketAddress resolveOriginAddress(HttpServerRequest request) {
+    return null;
+  }
+
+  public void originSelector(HttpProxy proxy) {
+    proxy.originSelector(request -> Future.succeededFuture(resolveOriginAddress(request)));
+  }
+
+  private RequestOptions resolveOriginOptions(HttpServerRequest request) {
+    return null;
+  }
+
+  public void originRequestProvider(HttpProxy proxy) {
+    proxy.originRequestProvider((request, client) -> client.request(resolveOriginOptions(request)));
   }
 
   public void inboundInterceptor(HttpProxy proxy) {
@@ -126,8 +144,8 @@ public class HttpProxyExamples {
 
   public void lowLevel(Vertx vertx, HttpServer proxyServer, HttpClient proxyClient) {
 
-    proxyServer.requestHandler(outboundRequest -> {
-      ProxyRequest proxyRequest = ProxyRequest.reverseProxy(outboundRequest);
+    proxyServer.requestHandler(request -> {
+      ProxyRequest proxyRequest = ProxyRequest.reverseProxy(request);
 
       proxyClient.request(proxyRequest.getMethod(), 8080, "origin", proxyRequest.getURI())
         .compose(proxyRequest::send)
@@ -140,7 +158,7 @@ public class HttpProxyExamples {
         proxyRequest.release();
 
         // Send error
-        outboundRequest.response().setStatusCode(500)
+        request.response().setStatusCode(500)
           .send();
       });
     });


### PR DESCRIPTION
Sometimes the developer needs more control over the HTTP request to the origin server. Our proxy is currently limited to the socket address of the origin server. The origin request provider allows the developer to fully create the request to the origin server given the incoming HTTP request and the HTTP client.

fixes #37