### PR TITLE
Use HttpServerRequest authority() pre-parsed authority instead of the deprecated host()

### DIFF
--- a/src/main/java/examples/HttpProxyExamples.java
+++ b/src/main/java/examples/HttpProxyExamples.java
@@ -8,6 +8,7 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.RequestOptions;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.httpproxy.Body;
 import io.vertx.httpproxy.HttpProxy;
@@ -169,7 +170,7 @@ public class HttpProxyExamples {
       @Override
       public Future<ProxyResponse> handleProxyRequest(ProxyContext context) {
         ProxyRequest proxyRequest = context.request();
-        proxyRequest.setAuthority("example.com:80");
+        proxyRequest.setAuthority(HostAndPort.create("example.com", 80));
         return ProxyInterceptor.super.handleProxyRequest(context);
       }
     });

--- a/src/main/java/io/vertx/httpproxy/ProxyRequest.java
+++ b/src/main/java/io/vertx/httpproxy/ProxyRequest.java
@@ -19,6 +19,7 @@ import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.httpproxy.impl.ProxiedRequest;
 
 /**
@@ -113,12 +114,12 @@ public interface ProxyRequest {
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  ProxyRequest setAuthority(String authority);
+  ProxyRequest setAuthority(HostAndPort authority);
 
   /**
    * @return the request authority, for HTTP2 the {@literal :authority} pseudo header otherwise the {@literal Host} header
    */
-  String getAuthority();
+  HostAndPort getAuthority();
 
   /**
    * @return the headers that will be sent to the origin server, the returned headers can be modified. The headers

--- a/src/main/java/io/vertx/httpproxy/impl/ProxiedRequest.java
+++ b/src/main/java/io/vertx/httpproxy/impl/ProxiedRequest.java
@@ -23,6 +23,7 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.impl.HttpServerRequestInternal;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.streams.Pipe;
 import io.vertx.httpproxy.Body;
 import io.vertx.httpproxy.ProxyRequest;
@@ -51,7 +52,7 @@ public class ProxiedRequest implements ProxyRequest {
   private String uri;
   private final String absoluteURI;
   private Body body;
-  private String authority;
+  private HostAndPort authority;
   private final MultiMap headers;
   HttpClientRequest request;
   private final HttpServerRequest proxiedRequest;
@@ -77,7 +78,7 @@ public class ProxiedRequest implements ProxyRequest {
     this.absoluteURI = proxiedRequest.absoluteURI();
     this.proxiedRequest = proxiedRequest;
     this.context = (ContextInternal) ((HttpServerRequestInternal) proxiedRequest).context();
-    this.authority = proxiedRequest.host();
+    this.authority = proxiedRequest.authority();
   }
 
   @Override
@@ -108,14 +109,14 @@ public class ProxiedRequest implements ProxyRequest {
   }
 
   @Override
-  public ProxyRequest setAuthority(String authority) {
+  public ProxyRequest setAuthority(HostAndPort authority) {
     Objects.requireNonNull(authority);
     this.authority= authority;
     return this;
   }
 
   @Override
-  public String getAuthority() {
+  public HostAndPort getAuthority() {
     return authority;
   }
 
@@ -174,32 +175,13 @@ public class ProxiedRequest implements ProxyRequest {
     }
 
     //
-    String proxiedAuthority = proxiedRequest.host();
-    int idx = proxiedAuthority.indexOf(':');
-    String proxiedHost;
-    int proxiedPort;
-    if (idx == -1) {
-      proxiedHost = proxiedAuthority;
-      proxiedPort = -1;
-    } else {
-      proxiedHost = proxiedAuthority.substring(0, idx);
-      proxiedPort = Integer.parseInt(proxiedAuthority.substring(idx + 1));
-    }
-
-    String host;
-    int port;
-    idx = authority.indexOf(':');
-    if (idx == -1) {
-      host = authority;
-      port = -1;
-    } else {
-      host = authority.substring(0, idx);
-      port = Integer.parseInt(authority.substring(idx + 1));
-    }
-    request.setHost(host);
-    request.setPort(port == -1 ? (request.absoluteURI().startsWith("https://") ? 443 : 80) : port);
-    if (!proxiedHost.equals(host) || proxiedPort != port) {
-      request.putHeader(X_FORWARDED_HOST, proxiedAuthority);
+    if (authority != null) {
+      request.authority(authority);
+      HostAndPort proxiedAuthority = proxiedRequest.authority();
+      if (!equals(authority, proxiedAuthority)) {
+        // Should cope with existing forwarded host headers
+        request.putHeader(X_FORWARDED_HOST, proxiedAuthority.toString());
+      }
     }
 
     long len = body.length();
@@ -218,6 +200,13 @@ public class ProxiedRequest implements ProxyRequest {
         request.reset();
       }
     });
+  }
+
+  private static boolean equals(HostAndPort hp1, HostAndPort hp2) {
+    if (hp1 == null || hp2 == null) {
+      return false;
+    }
+    return hp1.host().equals(hp2.host()) && hp1.port() == hp2.port();
   }
 
   @Override


### PR DESCRIPTION
The proxy uses and expose the authority as a host header, performing limited host header parsing (IPV6 host are not parsed).

Instead of relying on the HttpServerRequest#host() method, use HttpServerRequest#authority() which provides the same value parsed as an HostAndPort instance.
