### PR TITLE
Use HttpServerRequest authority() pre-parsed authority instead of the deprecated host()

### DIFF
--- a/src/main/java/examples/HttpProxyExamples.java
+++ b/src/main/java/examples/HttpProxyExamples.java
@@ -8,6 +8,7 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.RequestOptions;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.httpproxy.Body;
 import io.vertx.httpproxy.HttpProxy;
@@ -169,7 +170,7 @@ public class HttpProxyExamples {
       @Override
       public Future<ProxyResponse> handleProxyRequest(ProxyContext context) {
         ProxyRequest proxyRequest = context.request();
-        proxyRequest.setAuthority("example.com:80");
+        proxyRequest.setAuthority(HostAndPort.create("example.com", 80));
         return ProxyInterceptor.super.handleProxyRequest(context);
       }
     });

--- a/src/main/java/io/vertx/httpproxy/ProxyRequest.java
+++ b/src/main/java/io/vertx/httpproxy/ProxyRequest.java
@@ -19,6 +19,7 @@ import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.httpproxy.impl.ProxiedRequest;
 
 /**
@@ -113,12 +114,12 @@ public interface ProxyRequest {
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  ProxyRequest setAuthority(String authority);
+  ProxyRequest setAuthority(HostAndPort authority);
 
   /**
    * @return the request authority, for HTTP2 the {@literal :authority} pseudo header otherwise the {@literal Host} header
    */
-  String getAuthority();
+  HostAndPort getAuthority();
 
   /**
    * @return the headers that will be sent to the origin server, the returned headers can be modified. The headers

--- a/src/test/java/io/vertx/httpproxy/ProxyClientKeepAliveTest.java
+++ b/src/test/java/io/vertx/httpproxy/ProxyClientKeepAliveTest.java
@@ -14,11 +14,13 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
+import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.WriteStream;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.Closeable;
@@ -737,21 +739,61 @@ public class ProxyClientKeepAliveTest extends ProxyTestBase {
   }
 
   @Test
+  public void testIPV6Authority(TestContext ctx) {
+    testAuthority(ctx, HostAndPort.authority("[7a03:908:671:b520:ba27:bbff:ffff:fed2]", 1234));
+  }
+
+  @Test
+  public void testIPV4Authority(TestContext ctx) {
+    testAuthority(ctx, HostAndPort.authority("192.168.0.1", 1234));
+  }
+
+  @Test
+  public void testMissingPortAuthority(TestContext ctx) {
+    testAuthority(ctx, HostAndPort.authority("localhost", -1));
+  }
+
+  private void testAuthority(TestContext ctx, HostAndPort requestAuthority) {
+    SocketAddress backend = startHttpBackend(ctx, 8081, req -> {
+      ctx.assertEquals("/somepath", req.uri());
+      ctx.assertEquals(requestAuthority.host(), req.authority().host());
+      ctx.assertEquals(requestAuthority.port(), req.authority().port());
+      ctx.assertEquals(null, req.getHeader("x-forwarded-host"));
+      req.response().end("Hello World");
+    });
+    startProxy(proxy -> {
+      proxy.origin(backend);
+    });
+    HttpClient client = vertx.createHttpClient();
+    client.request(GET, 8080, "localhost", "/somepath")
+      .compose(req -> req
+        .authority(requestAuthority)
+        .send()
+        .compose(resp -> {
+          ctx.assertEquals(200, resp.statusCode());
+          return resp.body();
+        }))
+      .onComplete(ctx.asyncAssertSuccess(body -> {
+        ctx.assertEquals("Hello World", body.toString());
+      }));
+  }
+
+  @Test
   public void testAuthorityOverride1(TestContext ctx) {
-    testAuthorityOverride(ctx, "foo:8080", "foo:8080", "localhost:8080");
+    testAuthorityOverride(ctx, HostAndPort.authority("foo", 8080), "foo:8080", "localhost:8080");
   }
 
   @Test
   public void testAuthorityOverride2(TestContext ctx) {
-    testAuthorityOverride(ctx, "foo", "foo", "localhost:8080");
+    testAuthorityOverride(ctx, HostAndPort.authority("foo"), "foo", "localhost:8080");
   }
 
   @Test
   public void testAuthorityOverride3(TestContext ctx) {
-    testAuthorityOverride(ctx, "localhost:8080", "localhost:8080", null);
+    testAuthorityOverride(ctx, HostAndPort.authority("localhost", 8080), "localhost:8080", null);
   }
 
-  private void testAuthorityOverride(TestContext ctx, String authority, String expectedAuthority, String expectedForwardedHost) {
+  private void testAuthorityOverride(TestContext ctx, HostAndPort authority, String expectedAuthority, String expectedForwardedHost) {
     SocketAddress backend = startHttpBackend(ctx, 8081, req -> {
       ctx.assertEquals("/somepath", req.uri());
       ctx.assertEquals(expectedAuthority, req.authority().toString());
@@ -764,7 +806,8 @@ public class ProxyClientKeepAliveTest extends ProxyTestBase {
         @Override
         public Future<ProxyResponse> handleProxyRequest(ProxyContext context) {
           ProxyRequest request = context.request();
-          ctx.assertEquals("localhost:8080", request.getAuthority());
+          ctx.assertEquals("localhost", request.getAuthority().host());
+          ctx.assertEquals(8080, request.getAuthority().port());
           request.setAuthority(authority);
           return ProxyInterceptor.super.handleProxyRequest(context);
         }


### PR DESCRIPTION
The proxy uses and expose the authority as a host header, performing limited host header parsing (IPV6 host are not parsed).

Instead of relying on the HttpServerRequest#host() method, use HttpServerRequest#authority() which provides the same value parsed as an HostAndPort instance.
