### PR TITLE
Ignore host header in proxied request regardless it's casing

### DIFF
--- a/src/main/java/io/vertx/httpproxy/impl/ProxiedRequest.java
+++ b/src/main/java/io/vertx/httpproxy/impl/ProxiedRequest.java
@@ -169,7 +169,7 @@ public class ProxiedRequest implements ProxyRequest {
     for (Map.Entry<String, String> header : headers) {
       String name = header.getKey();
       String value = header.getValue();
-      if (!HOP_BY_HOP_HEADERS.contains(name) && !name.equals("host")) {
+      if (!HOP_BY_HOP_HEADERS.contains(name) && !name.equalsIgnoreCase("host")) {
         request.headers().add(name, value);
       }
     }

--- a/src/test/java/io/vertx/httpproxy/ProxyRequestTest.java
+++ b/src/test/java/io/vertx/httpproxy/ProxyRequestTest.java
@@ -448,6 +448,7 @@ public class ProxyRequestTest extends ProxyTestBase {
   @Test
   public void testUpdateRequestHeaders(TestContext ctx) throws Exception {
     SocketAddress backend = startHttpBackend(ctx, 8081, req -> {
+      ctx.assertNotEquals("example.org", req.getHeader("Host"));
       ctx.assertNull(req.getHeader("header"));
       ctx.assertEquals("proxy_header_value", req.getHeader("proxy_header"));
       req.response().putHeader("header", "header_value").end();
@@ -456,6 +457,7 @@ public class ProxyRequestTest extends ProxyTestBase {
     startHttpServer(ctx, serverOptions, req -> {
       ProxyRequest proxyReq = ProxyRequest.reverseProxy(req);
       MultiMap clientHeaders = proxyReq.headers();
+      clientHeaders.add("Host", "example.org");
       clientHeaders.add("proxy_header", "proxy_header_value");
       ctx.assertEquals("header_value", clientHeaders.get("header"));
       clientHeaders.remove("header");


### PR DESCRIPTION
Resolves #77

Motivation:
I encountered an edge case which is not handled properly. The method sendRequest in the class ProxiedRequest ignores on line 173 the "host" header. In our application, I encountered the issue, that the "Host" header is starting with an Uppercase letter. Therefore it is added to the request on line 174, but it shouldn't.

This fix ignores the host header regardless it's casing.
