### PR TITLE
Match interceptor proposal

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -140,3 +140,29 @@ You can change the control, e.g you can send a response immediately to the user-
 ----
 {@link examples.HttpProxyExamples#immediateResponse}
 ----
+
+=== Pre-defined interceptors
+
+You also use pre-defined interceptors to perform common transformations.
+
+==== Common interceptors
+
+// TODO
+
+==== Match interceptor
+
+A match interceptor is a special interceptor that combines the functionality of common interceptors. It consists of two groups of methods, *matchers* and *transformers*. Matchers are used to capture the value in the request or response into the context and to decide if the interceptor continues itself; transformers are used to transform the request and response with the context.
+
+Your can use literals that start with symbol `$` to represent variables for value extraction and injection:
+
+[source,java]
+----
+{@link examples.HttpProxyExamples#matchInterceptorLiterals}
+----
+
+In addition to using literals to represent transformations, most matchers and transformers also accept functional parameters:
+
+[source,java]
+----
+{@link examples.HttpProxyExamples#matchInterceptorFunctionals}
+----

--- a/src/main/java/examples/HttpProxyExamples.java
+++ b/src/main/java/examples/HttpProxyExamples.java
@@ -18,6 +18,7 @@ import io.vertx.httpproxy.ProxyOptions;
 import io.vertx.httpproxy.ProxyRequest;
 import io.vertx.httpproxy.ProxyResponse;
 import io.vertx.httpproxy.cache.CacheOptions;
+import io.vertx.httpproxy.interceptors.MatchInterceptor;
 
 /**
  * @author <a href="mailto:emad.albloushi@gmail.com">Emad Alblueshi</a>
@@ -127,6 +128,28 @@ public class HttpProxyExamples {
         return Future.succeededFuture(proxyResponse);
       }
     });
+  }
+
+  public void matchInterceptorLiterals() {
+    // To put the header "token" into the params and rename it "app_token"
+    MatchInterceptor.builder()
+      .matchRequestHeaders("token")
+      .updateParams("app_token", "$token");
+  }
+
+  public void matchInterceptorFunctionals() {
+    MatchInterceptor.builder()
+      .matchRequestHeaders((ctx, headers) -> {
+        if (headers.contains("token")) {
+          ctx.set("token", headers.get("token"));
+          return true; // returns true if interceptor continues
+        }
+        return false; // return false if not
+      })
+      .transformParams((ctx, params) -> {
+        params.set("app_token", ctx.get("token", String.class));
+        return params;
+      });
   }
 
   private void filter(MultiMap headers) {

--- a/src/main/java/io/vertx/httpproxy/interceptors/HeadersInterceptor.java
+++ b/src/main/java/io/vertx/httpproxy/interceptors/HeadersInterceptor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.httpproxy.interceptors;
+
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.httpproxy.ProxyInterceptor;
+import io.vertx.httpproxy.interceptors.impl.HeadersInterceptorImpl;
+
+import java.util.Set;
+
+import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
+
+@VertxGen
+public interface HeadersInterceptor {
+
+  @GenIgnore(PERMITTED_TYPE)
+  static ProxyInterceptor filterRequestHeaders(Set<CharSequence> requestHeaders) {
+    return new HeadersInterceptorImpl(); // FIXME
+  }
+
+  @GenIgnore(PERMITTED_TYPE)
+  static ProxyInterceptor filterResponseHeaders(Set<CharSequence> responseHeaders) {
+    return new HeadersInterceptorImpl(); // FIXME
+  }
+
+  @GenIgnore(PERMITTED_TYPE)
+  static ProxyInterceptor filterHeaders(Set<CharSequence> requestHeaders, Set<CharSequence> responseHeaders) {
+    return new HeadersInterceptorImpl(); // FIXME
+  }
+}

--- a/src/main/java/io/vertx/httpproxy/interceptors/MatchInterceptor.java
+++ b/src/main/java/io/vertx/httpproxy/interceptors/MatchInterceptor.java
@@ -1,16 +1,23 @@
 package io.vertx.httpproxy.interceptors;
 
+import io.vertx.codegen.annotations.Unstable;
+import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.httpproxy.ProxyContext;
+import io.vertx.httpproxy.ProxyInterceptor;
+import io.vertx.httpproxy.interceptors.impl.MatchInterceptorImpl;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-public interface MatchInterceptor {
+@VertxGen
+@Unstable
+public interface MatchInterceptor extends ProxyInterceptor {
   static MatchInterceptor builder() {
-    return null;
+    return new MatchInterceptorImpl();
   }
 
   // Path:
@@ -29,16 +36,16 @@ public interface MatchInterceptor {
 
   MatchInterceptor transformParams(BiFunction<ProxyContext, MultiMap, MultiMap> transformer);
 
-  MatchInterceptor updateParam(String name, String value);
-  MatchInterceptor removeParam(String name);
+  MatchInterceptor updateParams(String name, String value);
+  MatchInterceptor removeParams(String name);
 
 
   // Headers:
-  MatchInterceptor matchRequestHeaders(String paramName, String alias);
-  MatchInterceptor matchRequestHeaders(String paramName);
+  MatchInterceptor matchRequestHeaders(String headerName, String alias);
+  MatchInterceptor matchRequestHeaders(String headerName);
   MatchInterceptor matchRequestHeaders(BiFunction<ProxyContext, MultiMap, Boolean> matcher);
-  MatchInterceptor matchResponseHeaders(String paramName, String alias);
-  MatchInterceptor matchResponseHeaders(String paramName);
+  MatchInterceptor matchResponseHeaders(String headerName, String alias);
+  MatchInterceptor matchResponseHeaders(String headerName);
   MatchInterceptor matchResponseHeaders(BiFunction<ProxyContext, MultiMap, Boolean> matcher);
 
   MatchInterceptor transformRequestHeaders(BiFunction<ProxyContext, MultiMap, MultiMap> transformer);
@@ -51,11 +58,11 @@ public interface MatchInterceptor {
 
 
   // Body:
-  <T> MatchInterceptor matchRequestBody(BiFunction<ProxyContext, T, Boolean> matcher);
-  <T> MatchInterceptor matchResponseBody(BiFunction<ProxyContext, T, Boolean> matcher);
+  <T> MatchInterceptor matchRequestBody(BiFunction<ProxyContext, T, Boolean> matcher, Class<T> inputRequestType);
+  <T> MatchInterceptor matchResponseBody(BiFunction<ProxyContext, T, Boolean> matcher, Class<T> inputResponseType);
 
-  <T, R> MatchInterceptor transformRequestBody(BiFunction<ProxyContext, T, R> transformer);
-  <T, R> MatchInterceptor transformResponseBody(BiFunction<ProxyContext, T, R> transformer);
+  <T> MatchInterceptor transformRequestBody(BiFunction<ProxyContext, T, Object> transformer, Class<T> inputRequestType);
+  <T> MatchInterceptor transformResponseBody(BiFunction<ProxyContext, T, Object> transformer, Class<T> inputResponseType);
 
   MatchInterceptor updateRequestJsonField(String name, String value);
   MatchInterceptor removeRequestJsonField(String name, String value);

--- a/src/main/java/io/vertx/httpproxy/interceptors/MatchInterceptor.java
+++ b/src/main/java/io/vertx/httpproxy/interceptors/MatchInterceptor.java
@@ -1,0 +1,72 @@
+package io.vertx.httpproxy.interceptors;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.httpproxy.ProxyContext;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public interface MatchInterceptor {
+  static MatchInterceptor builder() {
+    return null;
+  }
+
+  // Path:
+  MatchInterceptor matchPath(String path);
+  MatchInterceptor matchPath(BiFunction<ProxyContext, String, Boolean> matcher);
+
+  MatchInterceptor transformPath(BiFunction<ProxyContext, String, String> transformer);
+
+  MatchInterceptor updatePath(String transformer);
+  MatchInterceptor addPathPrefix(String prefix);
+  MatchInterceptor removePathPrefix(String prefix);
+
+  // Params:
+  MatchInterceptor matchParams(String paramName, String alias);
+  MatchInterceptor matchParams(String paramName);
+
+  MatchInterceptor transformParams(BiFunction<ProxyContext, MultiMap, MultiMap> transformer);
+
+  MatchInterceptor updateParam(String name, String value);
+  MatchInterceptor removeParam(String name);
+
+
+  // Headers:
+  MatchInterceptor matchRequestHeaders(String paramName, String alias);
+  MatchInterceptor matchRequestHeaders(String paramName);
+  MatchInterceptor matchRequestHeaders(BiFunction<ProxyContext, MultiMap, Boolean> matcher);
+  MatchInterceptor matchResponseHeaders(String paramName, String alias);
+  MatchInterceptor matchResponseHeaders(String paramName);
+  MatchInterceptor matchResponseHeaders(BiFunction<ProxyContext, MultiMap, Boolean> matcher);
+
+  MatchInterceptor transformRequestHeaders(BiFunction<ProxyContext, MultiMap, MultiMap> transformer);
+  MatchInterceptor transformResponseHeaders(BiFunction<ProxyContext, MultiMap, MultiMap> transformer);
+
+  MatchInterceptor updateRequestHeaders(String name, String value);
+  MatchInterceptor removeRequestHeaders(String name);
+  MatchInterceptor updateResponseHeaders(String name, String value);
+  MatchInterceptor removeResponseHeaders(String name);
+
+
+  // Body:
+  <T> MatchInterceptor matchRequestBody(BiFunction<ProxyContext, T, Boolean> matcher);
+  <T> MatchInterceptor matchResponseBody(BiFunction<ProxyContext, T, Boolean> matcher);
+
+  <T, R> MatchInterceptor transformRequestBody(BiFunction<ProxyContext, T, R> transformer);
+  <T, R> MatchInterceptor transformResponseBody(BiFunction<ProxyContext, T, R> transformer);
+
+  MatchInterceptor updateRequestJsonField(String name, String value);
+  MatchInterceptor removeRequestJsonField(String name, String value);
+  MatchInterceptor updateResponseJsonField(String name, String value);
+  MatchInterceptor removeResponseJsonField(String name, String value);
+
+  // HTTP method:
+  MatchInterceptor matchHttpMethods(List<HttpMethod> methods, String alias);
+
+  MatchInterceptor transformHttpMethods(BiFunction<ProxyContext, HttpMethod, HttpMethod> transformer);
+
+  MatchInterceptor updateHttpMethods(HttpMethod method);
+
+}

--- a/src/main/java/io/vertx/httpproxy/interceptors/PathInterceptor.java
+++ b/src/main/java/io/vertx/httpproxy/interceptors/PathInterceptor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.httpproxy.interceptors;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.httpproxy.ProxyInterceptor;
+import io.vertx.httpproxy.interceptors.impl.AddPrefixPathInterceptorImpl;
+import io.vertx.httpproxy.interceptors.impl.RemovePrefixPathInterceptorImpl;
+
+@VertxGen
+public interface PathInterceptor {
+
+  static ProxyInterceptor removePrefix(String prefix) {
+    return new RemovePrefixPathInterceptorImpl(); // FIXME
+  }
+
+  static ProxyInterceptor addPrefix(String prefix) {
+    return new AddPrefixPathInterceptorImpl(); // FIXME
+  }
+}

--- a/src/main/java/io/vertx/httpproxy/interceptors/impl/AddPrefixPathInterceptorImpl.java
+++ b/src/main/java/io/vertx/httpproxy/interceptors/impl/AddPrefixPathInterceptorImpl.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.httpproxy.interceptors.impl;
+
+import io.vertx.httpproxy.ProxyInterceptor;
+
+public class AddPrefixPathInterceptorImpl implements ProxyInterceptor {
+
+  // FIXME
+
+}

--- a/src/main/java/io/vertx/httpproxy/interceptors/impl/HeadersInterceptorImpl.java
+++ b/src/main/java/io/vertx/httpproxy/interceptors/impl/HeadersInterceptorImpl.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.httpproxy.interceptors.impl;
+
+import io.vertx.httpproxy.ProxyInterceptor;
+
+public class HeadersInterceptorImpl implements ProxyInterceptor {
+
+  // FIXME
+
+}

--- a/src/main/java/io/vertx/httpproxy/interceptors/impl/MatchInterceptorImpl.java
+++ b/src/main/java/io/vertx/httpproxy/interceptors/impl/MatchInterceptorImpl.java
@@ -1,0 +1,313 @@
+package io.vertx.httpproxy.interceptors.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.httpproxy.ProxyContext;
+import io.vertx.httpproxy.ProxyInterceptor;
+import io.vertx.httpproxy.ProxyRequest;
+import io.vertx.httpproxy.ProxyResponse;
+import io.vertx.httpproxy.interceptors.MatchInterceptor;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public class MatchInterceptorImpl implements MatchInterceptor {
+  private final List<Function<ProxyContext, Future<Boolean>>> requestHandlers = new ArrayList<>();
+  private final List<Function<ProxyContext, Future<Boolean>>> responseHandlers = new ArrayList<>();
+
+  private Future<Boolean> iterAsyncHandlers(ProxyContext context, Iterator<Function<ProxyContext, Future<Boolean>>> iterator) {
+    if (iterator.hasNext()) {
+      return iterator.next().apply(context)
+        .compose(useNext -> useNext ? iterAsyncHandlers(context, iterator) : Future.succeededFuture(null));
+    } else {
+      return Future.succeededFuture(null);
+    }
+  }
+
+  @Override
+  public Future<ProxyResponse> handleProxyRequest(ProxyContext context) {
+    Iterator<Function<ProxyContext, Future<Boolean>>> iterator = requestHandlers.iterator();
+    return iterAsyncHandlers(context, iterator).compose(x -> context.sendRequest());
+  }
+
+  @Override
+  public Future<Void> handleProxyResponse(ProxyContext context) {
+    Iterator<Function<ProxyContext, Future<Boolean>>> iterator = responseHandlers.iterator();
+    return iterAsyncHandlers(context, iterator).compose(x -> context.sendResponse());
+  }
+
+  @Override
+  public MatchInterceptor matchPath(String path) {
+    Objects.requireNonNull(path);
+    requestHandlers.add(ctx -> {
+      boolean matched = StringUtils.matchURL(ctx.request().getURI(), path);
+      if (!matched) return Future.succeededFuture(false);
+      StringUtils.fillContextWithURL(ctx.request().getURI(), path, ctx);
+      return Future.succeededFuture(true);
+    });
+    return this;
+  }
+
+  @Override
+  public MatchInterceptor matchPath(BiFunction<ProxyContext, String, Boolean> matcher) {
+    Objects.requireNonNull(matcher);
+    requestHandlers.add(ctx -> Future.succeededFuture(matcher.apply(ctx, ctx.request().getURI())));
+    return this;
+  }
+
+  @Override
+  public MatchInterceptor transformPath(BiFunction<ProxyContext, String, String> transformer) {
+    Objects.requireNonNull(transformer);
+    requestHandlers.add(ctx -> {
+      ctx.request().setURI(transformer.apply(ctx, ctx.request().getURI()));
+      return Future.succeededFuture(true);
+    });
+    return this;
+  }
+
+  @Override
+  public MatchInterceptor updatePath(String transformer) {
+    Objects.requireNonNull(transformer);
+    requestHandlers.add(ctx -> {
+      ctx.request().setURI(StringUtils.transformURL(transformer, ctx));
+      return Future.succeededFuture(true);
+    });
+    return this;
+  }
+
+  @Override
+  public MatchInterceptor addPathPrefix(String prefix) {
+    Objects.requireNonNull(prefix);
+    requestHandlers.add(ctx -> {
+      String prefixActual = StringUtils.transformURL(prefix, ctx);
+      ctx.request().setURI(prefixActual + ctx.request().getURI());
+      return Future.succeededFuture(true);
+    });
+    return this;
+  }
+
+  @Override
+  public MatchInterceptor removePathPrefix(String prefix) {
+    Objects.requireNonNull(prefix);
+    requestHandlers.add(ctx -> {
+      String prefixActual = StringUtils.transformURL(prefix, ctx);
+      String oldURI = ctx.request().getURI();
+      if (oldURI.startsWith(prefixActual)) {
+        ctx.request().setURI(oldURI.substring(prefixActual.length()));
+      }
+      return Future.succeededFuture(true);
+    });
+    return this;
+  }
+
+  @Override
+  public MatchInterceptor matchParams(String paramName, String alias) {
+    return null;
+  }
+
+  @Override
+  public MatchInterceptor matchParams(String paramName) {
+    return null;
+  }
+
+  @Override
+  public MatchInterceptor transformParams(BiFunction<ProxyContext, MultiMap, MultiMap> transformer) {
+    return null;
+  }
+
+  @Override
+  public MatchInterceptor updateParams(String name, String value) {
+    return null;
+  }
+
+  @Override
+  public MatchInterceptor removeParams(String name) {
+    return null;
+  }
+
+  @Override
+  public MatchInterceptor matchRequestHeaders(String headerName, String alias) {
+    Objects.requireNonNull(headerName);
+    Objects.requireNonNull(alias);
+    requestHandlers.add(ctx -> {
+      String value = ctx.request().headers().get(StringUtils.substitute(headerName, ctx));
+      if (value == null) return Future.succeededFuture(false);
+      ctx.set(StringUtils.substitute(headerName, ctx), value);
+      return Future.succeededFuture(true);
+    });
+    return this;
+  }
+
+  @Override
+  public MatchInterceptor matchRequestHeaders(String headerName) {
+    Objects.requireNonNull(headerName);
+    return matchRequestHeaders(headerName, headerName);
+  }
+
+  @Override
+  public MatchInterceptor matchRequestHeaders(BiFunction<ProxyContext, MultiMap, Boolean> matcher) {
+    Objects.requireNonNull(matcher);
+    requestHandlers.add(ctx -> Future.succeededFuture(matcher.apply(ctx, ctx.request().headers())));
+    return this;
+  }
+
+  @Override
+  public MatchInterceptor matchResponseHeaders(String headerName, String alias) {
+    Objects.requireNonNull(headerName);
+    Objects.requireNonNull(alias);
+    responseHandlers.add(ctx -> {
+      String value = ctx.response().headers().get(StringUtils.substitute(headerName, ctx));
+      if (value == null) return Future.succeededFuture(false);
+      ctx.set(StringUtils.substitute(alias, ctx), value);
+      return Future.succeededFuture(true);
+    });
+    return this;
+  }
+
+  @Override
+  public MatchInterceptor matchResponseHeaders(String headerName) {
+    Objects.requireNonNull(headerName);
+    return matchResponseHeaders(headerName, headerName);
+  }
+
+  @Override
+  public MatchInterceptor matchResponseHeaders(BiFunction<ProxyContext, MultiMap, Boolean> matcher) {
+    Objects.requireNonNull(matcher);
+    responseHandlers.add(ctx -> Future.succeededFuture(matcher.apply(ctx, ctx.response().headers())));
+    return this;
+  }
+
+  @Override
+  public MatchInterceptor transformRequestHeaders(BiFunction<ProxyContext, MultiMap, MultiMap> transformer) {
+    Objects.requireNonNull(transformer);
+    requestHandlers.add(ctx -> {
+      MultiMap newHeaders = transformer.apply(ctx, ctx.request().headers());
+      if (newHeaders != ctx.request().headers()) {
+        ctx.request().headers().clear().addAll(newHeaders);
+      }
+      return Future.succeededFuture(true);
+    });
+    return this;
+  }
+
+  @Override
+  public MatchInterceptor transformResponseHeaders(BiFunction<ProxyContext, MultiMap, MultiMap> transformer) {
+    Objects.requireNonNull(transformer);
+    responseHandlers.add(ctx -> {
+      MultiMap newHeaders = transformer.apply(ctx, ctx.response().headers());
+      if (newHeaders != ctx.response().headers()) {
+        ctx.response().headers().clear().addAll(newHeaders);
+      }
+      return Future.succeededFuture(true);
+    });
+    return this;
+  }
+
+  @Override
+  public MatchInterceptor updateRequestHeaders(String name, String value) {
+    Objects.requireNonNull(name);
+    Objects.requireNonNull(value);
+    requestHandlers.add(ctx -> {
+      String realName = StringUtils.substitute(name, ctx);
+      String realValue = StringUtils.substitute(value, ctx);
+      ctx.request().headers().set(realName, realValue);
+      return Future.succeededFuture(true);
+    });
+    return this;
+  }
+
+  @Override
+  public MatchInterceptor removeRequestHeaders(String name) {
+    Objects.requireNonNull(name);
+    requestHandlers.add(ctx -> {
+      String realName = StringUtils.substitute(name, ctx);
+      ctx.request().headers().remove(realName);
+      return Future.succeededFuture(true);
+    });
+    return this;
+  }
+
+  @Override
+  public MatchInterceptor updateResponseHeaders(String name, String value) {
+    Objects.requireNonNull(name);
+    Objects.requireNonNull(value);
+    responseHandlers.add(ctx -> {
+      String realName = StringUtils.substitute(name, ctx);
+      String realValue = StringUtils.substitute(value, ctx);
+      ctx.response().headers().set(realName, realValue);
+      return Future.succeededFuture(true);
+    });
+    return this;
+  }
+
+  @Override
+  public MatchInterceptor removeResponseHeaders(String name) {
+    Objects.requireNonNull(name);
+    responseHandlers.add(ctx -> {
+      String realName = StringUtils.substitute(name, ctx);
+      ctx.response().headers().remove(realName);
+      return Future.succeededFuture(true);
+    });
+    return this;
+  }
+
+  @Override
+  public <T> MatchInterceptor matchRequestBody(BiFunction<ProxyContext, T, Boolean> matcher, Class<T> inputRequestType) {
+    return null;
+  }
+
+  @Override
+  public <T> MatchInterceptor matchResponseBody(BiFunction<ProxyContext, T, Boolean> matcher, Class<T> inputResponseType) {
+    return null;
+  }
+
+  @Override
+  public <T> MatchInterceptor transformRequestBody(BiFunction<ProxyContext, T, Object> transformer, Class<T> inputRequestType) {
+    return null;
+  }
+
+  @Override
+  public <T> MatchInterceptor transformResponseBody(BiFunction<ProxyContext, T, Object> transformer, Class<T> inputResponseType) {
+    return null;
+  }
+
+  @Override
+  public MatchInterceptor updateRequestJsonField(String name, String value) {
+    return null;
+  }
+
+  @Override
+  public MatchInterceptor removeRequestJsonField(String name, String value) {
+    return null;
+  }
+
+  @Override
+  public MatchInterceptor updateResponseJsonField(String name, String value) {
+    return null;
+  }
+
+  @Override
+  public MatchInterceptor removeResponseJsonField(String name, String value) {
+    return null;
+  }
+
+  @Override
+  public MatchInterceptor matchHttpMethods(List<HttpMethod> methods, String alias) {
+    return null;
+  }
+
+  @Override
+  public MatchInterceptor transformHttpMethods(BiFunction<ProxyContext, HttpMethod, HttpMethod> transformer) {
+    return null;
+  }
+
+  @Override
+  public MatchInterceptor updateHttpMethods(HttpMethod method) {
+    return null;
+  }
+}

--- a/src/main/java/io/vertx/httpproxy/interceptors/impl/PathInterceptorImpl.java
+++ b/src/main/java/io/vertx/httpproxy/interceptors/impl/PathInterceptorImpl.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.httpproxy.interceptors.impl;
+
+import io.vertx.httpproxy.ProxyInterceptor;
+
+public class PathInterceptorImpl implements ProxyInterceptor {
+
+  // FIXME
+
+}

--- a/src/main/java/io/vertx/httpproxy/interceptors/impl/RemovePrefixPathInterceptorImpl.java
+++ b/src/main/java/io/vertx/httpproxy/interceptors/impl/RemovePrefixPathInterceptorImpl.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2011-2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.httpproxy.interceptors.impl;
+
+import io.vertx.httpproxy.ProxyInterceptor;
+
+public class RemovePrefixPathInterceptorImpl implements ProxyInterceptor {
+
+  // FIXME
+
+}

--- a/src/main/java/io/vertx/httpproxy/interceptors/impl/StringUtils.java
+++ b/src/main/java/io/vertx/httpproxy/interceptors/impl/StringUtils.java
@@ -1,0 +1,92 @@
+package io.vertx.httpproxy.interceptors.impl;
+
+import io.vertx.httpproxy.ProxyContext;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class StringUtils {
+
+  static String[] splitAndKeep(String str) {
+    ArrayList<String> parts = new ArrayList<>();
+    Pattern pattern = Pattern.compile("/");
+    Matcher matcher = pattern.matcher(str);
+
+    int lastIndex = 0;
+    while (matcher.find()) {
+      if (matcher.start() > lastIndex) {
+        parts.add(str.substring(lastIndex, matcher.start()));
+      }
+      parts.add(matcher.group());
+      lastIndex = matcher.end();
+    }
+    if (lastIndex < str.length()) {
+      parts.add(str.substring(lastIndex));
+    }
+    return parts.toArray(new String[0]);
+  }
+
+  static boolean matchURL(String raw, String pattern) {
+    String[] rawArr = splitAndKeep(raw);
+    String[] patternArr = splitAndKeep(pattern);
+    if (rawArr.length != patternArr.length) return false;
+
+    for (int i = 0; i < rawArr.length; i++) {
+      String rawPiece = rawArr[i];
+      String patternPiece = patternArr[i];
+      if ("/".equals(rawPiece) && !"/".equals(patternPiece)) return false;
+      if (!"/".equals(rawPiece) && "/".equals(patternPiece)) return false;
+      if (!patternPiece.startsWith("$") && !rawPiece.equals(patternPiece)) return false;
+    }
+    return true;
+  }
+
+  static void fillContextWithURL(String raw, String pattern, ProxyContext proxyContext) {
+    String[] rawArr = splitAndKeep(raw);
+    String[] patternArr = splitAndKeep(pattern);
+
+    for (int i = 0; i < rawArr.length; i++) {
+      String rawPiece = rawArr[i];
+      String patternPiece = patternArr[i];
+      if (patternPiece.startsWith("$")) {
+        proxyContext.set(patternPiece.substring(1), rawPiece);
+      }
+    }
+  }
+
+  static String transformURL(String pattern, ProxyContext proxyContext) {
+    String[] patternArr = splitAndKeep(pattern);
+    for (int i = 0; i < patternArr.length; i++) {
+      patternArr[i] = substitute(patternArr[i], proxyContext);
+    }
+    return String.join("", patternArr);
+  }
+
+  static String substitute(String pattern, ProxyContext proxyContext) {
+    if (pattern.startsWith("$")) {
+      Object value = proxyContext.get(pattern.substring(1), Object.class);
+      if (value == null) return pattern;
+      return value.toString();
+    }
+    return pattern;
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
It will add a general match interceptor `MatchInterceptor`, which can be used to match and transform request and responses among headers, params, body, and HTTP methods.

`MatchInterceptor` consists of two groups of methods, **matchers** and **transformers**. Matchers are used to capture the value in the request or response into the context and to decide if the interceptor itself continue to apply further matchers and transformers. Transformers are used to transform the request and response with the context.  

Following is an example about how to use it:

```java
// To put the header "token" into the params and rename it "app_token". These 2 ways are itentical:

// Literals
MatchInterceptor.builder()
    // match header "token" into the context's attachment
    .matchRequestHeaders("token") 
    // put a param named "app_token" with the value of token
    .updateParams("app_token", "$token"); 

// Functionals
MatchInterceptor.builder()
    // match header "token" into the context's attachment
    .matchRequestHeaders((ctx, headers) -> { 
        if (headers.contains("token")) {
            ctx.set("token", headers.get("token"));
            return true;
        }
        return false;
    })
    // put a param named "app_token" with the value of token
    .transformParams((ctx, params) -> { 
        params.set("app_token", ctx.get("token", String.class));
        return params;
    });

```

Both matchers and transformers can be written in the literal or functional manners. Literals uses mostly String to set up the proxy, which is easy and beneficial for configuration file usages. It use `$` for value extraction and injection. Example:

```java
MatchInterceptor.builder()
    .matchPath("api/v1/user/$name") // match the names to the context
    .updatePath("api/v1/user") // transform path
    .updateParams("user", "$name"); // use the name values from the context
```

Functionals are more flexible. They typically looks like this:

```java
// matcher:
(ProxyContext, T) -> Boolean

// transformer:
(ProxyContext, T) -> T
```

Matcher fetch values from `T` to put them into `ProxyContext`. It return `Boolean` to decide to continue this interceptor or not.

Transformer transforms `T` with values in `ProxyContext`.

Here I use the `ProxyContext` in the callback parameter because it could be helpful to share contextual data for issue 71. But I'm also worried that this will give user too much control for modifying the context itself. Maybe  I should only use the `Proxy.attachments` map in the callback (I'm assuming that is for contextual data sharing) ? 

