### PR TITLE
Assist in capturing and handling exceptions or errors within interceptors to prevent request hanging

### DIFF
--- a/src/main/java/io/vertx/httpproxy/impl/ReverseProxy.java
+++ b/src/main/java/io/vertx/httpproxy/impl/ReverseProxy.java
@@ -71,7 +71,7 @@ public class ReverseProxy implements HttpProxy {
     Proxy proxy = new Proxy(proxyRequest);
     proxy.filters = interceptors.listIterator();
     proxy.sendRequest()
-      .recover(throwable -> Future.succeededFuture(proxyRequest.response().setStatusCode(502)))
+      .recover(throwable -> Future.succeededFuture(proxyRequest.release().response().setStatusCode(502)))
       .compose(proxy::sendProxyResponse)
       .recover(throwable -> proxy.response().release().setStatusCode(502).send());
   }


### PR DESCRIPTION
This may help solve #75.  In addition, when interceptors fail to filter the request or response in the chain, this can return a response in time, preventing the request from hanging.
