### PR TITLE
JPMS support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,13 +53,15 @@
     </dependency>
 
     <!-- Only for fatjar -->
+<!--
     <dependency>
-      <!-- declare this dependency to force shiro to use this one. It is the version used by vert.x -->
+      &lt;!&ndash; declare this dependency to force shiro to use this one. It is the version used by vert.x &ndash;&gt;
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.16</version>
       <optional>true</optional>
     </dependency>
+-->
 
     <dependency>
       <groupId>io.vertx</groupId>
@@ -94,7 +96,7 @@
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-standalone</artifactId>
-      <version>2.6.0</version>
+      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -114,6 +116,16 @@
                   <annotationProcessor>io.vertx.codegen.CodeGenProcessor</annotationProcessor>
                   <annotationProcessor>io.vertx.docgen.JavaDocGenProcessor</annotationProcessor>
                 </annotationProcessors>
+                <annotationProcessorPaths>
+                  <annotationProcessorPath>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-codegen</artifactId>
+                  </annotationProcessorPath>
+                  <annotationProcessorPath>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-docgen</artifactId>
+                  </annotationProcessorPath>
+                </annotationProcessorPaths>
               </configuration>
             </execution>
           </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -52,17 +52,6 @@
       <artifactId>vertx-core</artifactId>
     </dependency>
 
-    <!-- Only for fatjar -->
-<!--
-    <dependency>
-      &lt;!&ndash; declare this dependency to force shiro to use this one. It is the version used by vert.x &ndash;&gt;
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.16</version>
-      <optional>true</optional>
-    </dependency>
--->
-
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-docgen</artifactId>
@@ -73,14 +62,6 @@
       <artifactId>vertx-codegen</artifactId>
       <scope>provided</scope>
     </dependency>
-
-<!--
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <version>1.0.13</version>
-    </dependency>
--->
 
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/io/vertx/httpproxy/cache/CacheOptions.java
+++ b/src/main/java/io/vertx/httpproxy/cache/CacheOptions.java
@@ -2,7 +2,6 @@ package io.vertx.httpproxy.cache;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.json.annotations.JsonGen;
-import io.vertx.core.impl.Arguments;
 import io.vertx.core.json.JsonObject;
 import io.vertx.httpproxy.impl.CacheImpl;
 import io.vertx.httpproxy.spi.cache.Cache;
@@ -39,7 +38,9 @@ public class CacheOptions {
    * @return a reference to this, so the API can be used fluently
    */
   public CacheOptions setMaxSize(int maxSize) {
-    Arguments.require(maxSize > 0, "Max size must be > 0");
+    if (maxSize <= 0) {
+      throw new IllegalArgumentException("Max size must be > 0");
+    }
     this.maxSize = maxSize;
     return this;
   }

--- a/src/main/java/io/vertx/httpproxy/impl/ReverseProxy.java
+++ b/src/main/java/io/vertx/httpproxy/impl/ReverseProxy.java
@@ -65,7 +65,7 @@ public class ReverseProxy implements HttpProxy {
     }
 
     // WebSocket upgrade tunneling
-    if (supportWebSocket && io.vertx.core.http.impl.HttpUtils.canUpgradeToWebSocket(request)) {
+    if (supportWebSocket && request.canUpgradeToWebSocket()) {
       handleWebSocketUpgrade(proxyRequest);
       return;
     }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+module io.vertx.httpproxy {
+  requires transitive io.vertx.core;
+  requires io.vertx.core.logging;
+  requires static io.vertx.codegen.api;
+  requires static io.vertx.codegen.json;
+  requires static vertx.docgen;
+  exports io.vertx.httpproxy;
+  exports io.vertx.httpproxy.cache;
+  exports io.vertx.httpproxy.spi.cache;
+  exports io.vertx.httpproxy.impl to io.vertx.tests;
+}

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,2 +1,0 @@
-Automatic-Module-Name: io.vertx.httpproxy
-

--- a/src/test/java/io/vertx/tests/BackendTest.java
+++ b/src/test/java/io/vertx/tests/BackendTest.java
@@ -1,4 +1,4 @@
-package io.vertx.httpproxy;
+package io.vertx.tests;
 
 import io.vertx.core.http.Cookie;
 import io.vertx.core.http.HttpClient;
@@ -6,6 +6,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.httpproxy.ProxyOptions;
 import org.junit.Test;
 
 /**

--- a/src/test/java/io/vertx/tests/ProxyClientKeepAliveTest.java
+++ b/src/test/java/io/vertx/tests/ProxyClientKeepAliveTest.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.httpproxy;
+package io.vertx.tests;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -20,6 +20,7 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.WriteStream;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.httpproxy.*;
 import org.junit.Test;
 
 import java.io.Closeable;

--- a/src/test/java/io/vertx/tests/ProxyClientNotPersistentTest.java
+++ b/src/test/java/io/vertx/tests/ProxyClientNotPersistentTest.java
@@ -8,16 +8,24 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.httpproxy;
+package io.vertx.tests;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.httpproxy.ProxyOptions;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class ProxyClientPipelinedTest extends ProxyClientKeepAliveTest {
+public class ProxyClientNotPersistentTest extends ProxyClientKeepAliveTest {
 
-  public ProxyClientPipelinedTest(ProxyOptions options) {
+  public ProxyClientNotPersistentTest(ProxyOptions options) {
     super(options);
-    keepAlive = true;
-    pipelining = true;
+    keepAlive = false;
+    pipelining = false;
+  }
+
+  public void testChunkedTransferEncodingRequest(TestContext ctx) {
+    // super.testChunkedTransferEncodingRequest(ctx);
+    // Does not pass for now - only when run in single
   }
 }

--- a/src/test/java/io/vertx/tests/ProxyClientPipelinedTest.java
+++ b/src/test/java/io/vertx/tests/ProxyClientPipelinedTest.java
@@ -8,23 +8,18 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.httpproxy;
+package io.vertx.tests;
 
-import io.vertx.ext.unit.TestContext;
+import io.vertx.httpproxy.ProxyOptions;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class ProxyClientNotPersistentTest extends ProxyClientKeepAliveTest {
+public class ProxyClientPipelinedTest extends ProxyClientKeepAliveTest {
 
-  public ProxyClientNotPersistentTest(ProxyOptions options) {
+  public ProxyClientPipelinedTest(ProxyOptions options) {
     super(options);
-    keepAlive = false;
-    pipelining = false;
-  }
-
-  public void testChunkedTransferEncodingRequest(TestContext ctx) {
-    // super.testChunkedTransferEncodingRequest(ctx);
-    // Does not pass for now - only when run in single
+    keepAlive = true;
+    pipelining = true;
   }
 }

--- a/src/test/java/io/vertx/tests/ProxyRequestTest.java
+++ b/src/test/java/io/vertx/tests/ProxyRequestTest.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.httpproxy;
+package io.vertx.tests;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -18,7 +18,6 @@ import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -32,6 +31,7 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.httpproxy.*;
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/src/test/java/io/vertx/tests/ProxyTest.java
+++ b/src/test/java/io/vertx/tests/ProxyTest.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.httpproxy;
+package io.vertx.tests;
 
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpClient;
@@ -18,6 +18,10 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunnerWithParametersFactory;
+import io.vertx.httpproxy.ProxyContext;
+import io.vertx.httpproxy.ProxyInterceptor;
+import io.vertx.httpproxy.ProxyOptions;
+import io.vertx.httpproxy.ProxyResponse;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/io/vertx/tests/ProxyTestBase.java
+++ b/src/test/java/io/vertx/tests/ProxyTestBase.java
@@ -8,9 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.httpproxy;
+package io.vertx.tests;
 
 import io.vertx.ext.unit.junit.VertxUnitRunnerWithParametersFactory;
+import io.vertx.httpproxy.ProxyOptions;
 import io.vertx.httpproxy.cache.CacheOptions;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/io/vertx/tests/TestBase.java
+++ b/src/test/java/io/vertx/tests/TestBase.java
@@ -22,7 +22,6 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.net.impl.SocketAddressImpl;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -134,7 +133,7 @@ public abstract class TestBase {
     Async async = ctx.async();
     backendServer.listen().onComplete(ctx.asyncAssertSuccess(s -> async.complete()));
     async.awaitSuccess();
-    return new SocketAddressImpl(options.getPort(), "localhost");
+    return SocketAddress.inetSocketAddress(options.getPort(), "localhost");
   }
 
   protected SocketAddress startNetBackend(TestContext ctx, int port, Handler<NetSocket> handler) {
@@ -143,7 +142,7 @@ public abstract class TestBase {
     Async async = ctx.async();
     backendServer.listen().onComplete(ctx.asyncAssertSuccess(s -> async.complete()));
     async.awaitSuccess();
-    return new SocketAddressImpl(port, "localhost");
+    return SocketAddress.inetSocketAddress(port, "localhost");
   }
 
 }

--- a/src/test/java/io/vertx/tests/TestBase.java
+++ b/src/test/java/io/vertx/tests/TestBase.java
@@ -8,10 +8,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.httpproxy;
+package io.vertx.tests;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -27,6 +26,8 @@ import io.vertx.core.net.impl.SocketAddressImpl;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.httpproxy.HttpProxy;
+import io.vertx.httpproxy.ProxyOptions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -34,7 +35,6 @@ import org.junit.runner.RunWith;
 import java.io.Closeable;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>

--- a/src/test/java/io/vertx/tests/WebSocketTest.java
+++ b/src/test/java/io/vertx/tests/WebSocketTest.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.httpproxy;
+package io.vertx.tests;
 
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
@@ -17,17 +17,9 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.ext.unit.junit.VertxUnitRunnerWithParametersFactory;
+import io.vertx.httpproxy.ProxyOptions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static io.vertx.core.http.HttpMethod.GET;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>

--- a/src/test/java/io/vertx/tests/cache/CacheConditionalGetTest.java
+++ b/src/test/java/io/vertx/tests/cache/CacheConditionalGetTest.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.httpproxy.cache;
+package io.vertx.tests.cache;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.vertx.core.http.HttpClient;

--- a/src/test/java/io/vertx/tests/cache/CacheConditionalGetTest.java
+++ b/src/test/java/io/vertx/tests/cache/CacheConditionalGetTest.java
@@ -14,7 +14,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.net.impl.SocketAddressImpl;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.httpproxy.impl.ParseUtils;
@@ -63,7 +63,7 @@ public class CacheConditionalGetTest extends CacheTestBase {
                 .withHeader("Last-Modified", ParseUtils.formatHttpDate(Instant.ofEpochMilli(now).minus(5000, ChronoUnit.MILLIS)))
                 .withHeader("Expires", ParseUtils.formatHttpDate(Instant.ofEpochMilli(now).plus(5000, ChronoUnit.MILLIS)))
                 .withBody("content")));
-    startProxy(new SocketAddressImpl(8081, "localhost"));
+    startProxy(SocketAddress.inetSocketAddress(8081, "localhost"));
     Async latch = ctx.async();
     client.request(HttpMethod.GET, 8080, "localhost", "/img.jpg").compose(req1 ->
       req1.send().compose(resp1 -> {

--- a/src/test/java/io/vertx/tests/cache/CacheExpires2Test.java
+++ b/src/test/java/io/vertx/tests/cache/CacheExpires2Test.java
@@ -17,7 +17,7 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.net.impl.SocketAddressImpl;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.httpproxy.impl.ParseUtils;
@@ -77,7 +77,7 @@ public class CacheExpires2Test extends CacheTestBase {
                 .withHeader("Date", ParseUtils.formatHttpDate(Instant.now()))
                 .withHeader("Expires", ParseUtils.formatHttpDate(Instant.now().plus(5000, ChronoUnit.MILLIS)))
                 .withBody("content2")));
-    startProxy(new SocketAddressImpl(8081, "localhost"));
+    startProxy(SocketAddress.inetSocketAddress(8081, "localhost"));
     Async latch = ctx.async();
     client.request(HttpMethod.GET, 8080, "localhost", "/img.jpg")
         .compose(req -> req
@@ -153,7 +153,7 @@ public class CacheExpires2Test extends CacheTestBase {
                 .withHeader("Etag", "tag1")
                 .withHeader("Date", ParseUtils.formatHttpDate(Instant.now()))
                 .withHeader("Expires", ParseUtils.formatHttpDate(Instant.now().plus(5000, ChronoUnit.MILLIS)))));
-    startProxy(new SocketAddressImpl(8081, "localhost"));
+    startProxy(SocketAddress.inetSocketAddress(8081, "localhost"));
     Async latch = ctx.async();
     client.request(HttpMethod.GET, 8080, "localhost", "/img.jpg")
         .compose(req1 -> req1
@@ -226,7 +226,7 @@ public class CacheExpires2Test extends CacheTestBase {
                 .withHeader("ETag", "tag0")
                 .withHeader("Date", ParseUtils.formatHttpDate(Instant.now()))
                 .withHeader("Expires", ParseUtils.formatHttpDate(Instant.now().plus(5000, ChronoUnit.MILLIS)))));
-    startProxy(new SocketAddressImpl(8081, "localhost"));
+    startProxy(SocketAddress.inetSocketAddress(8081, "localhost"));
     Async latch = ctx.async();
     client.request(HttpMethod.GET, 8080, "localhost", "/img.jpg")
         .compose(req1 -> req1.send()
@@ -277,7 +277,7 @@ public class CacheExpires2Test extends CacheTestBase {
                 .withHeader("ETag", "tag0")
                 .withHeader("Date", ParseUtils.formatHttpDate(Instant.now()))
                 .withHeader("Expires", ParseUtils.formatHttpDate(Instant.now().plus(5000, ChronoUnit.MILLIS)))));
-    startProxy(new SocketAddressImpl(8081, "localhost"));
+    startProxy(SocketAddress.inetSocketAddress(8081, "localhost"));
     Async latch = ctx.async();
     client.request(HttpMethod.HEAD, 8080, "localhost", "/img.jpg")
         .compose(req1 -> req1.send().compose(resp1 -> {

--- a/src/test/java/io/vertx/tests/cache/CacheExpires2Test.java
+++ b/src/test/java/io/vertx/tests/cache/CacheExpires2Test.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.httpproxy.cache;
+package io.vertx.tests.cache;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;

--- a/src/test/java/io/vertx/tests/cache/CacheExpiresTest.java
+++ b/src/test/java/io/vertx/tests/cache/CacheExpiresTest.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.httpproxy.cache;
+package io.vertx.tests.cache;
 
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;

--- a/src/test/java/io/vertx/tests/cache/CacheMaxAgeTest.java
+++ b/src/test/java/io/vertx/tests/cache/CacheMaxAgeTest.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.httpproxy.cache;
+package io.vertx.tests.cache;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;

--- a/src/test/java/io/vertx/tests/cache/CacheTestBase.java
+++ b/src/test/java/io/vertx/tests/cache/CacheTestBase.java
@@ -8,10 +8,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.httpproxy.cache;
+package io.vertx.tests.cache;
 
 import io.vertx.httpproxy.ProxyOptions;
-import io.vertx.httpproxy.TestBase;
+import io.vertx.httpproxy.cache.CacheOptions;
+import io.vertx.tests.TestBase;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>

--- a/src/test/java/io/vertx/tests/impl/ParseUtilsTest.java
+++ b/src/test/java/io/vertx/tests/impl/ParseUtilsTest.java
@@ -1,13 +1,12 @@
 package io.vertx.tests.impl;
 
 import io.vertx.httpproxy.impl.ParseUtils;
-import junit.framework.TestCase;
 import org.junit.Test;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class ParseUtilsTest {
 
@@ -20,7 +19,7 @@ public class ParseUtilsTest {
    */
   @Test
   public void testParseHttpDateRFC_1123_DATE_TIME() throws Exception {
-    TestCase.assertEquals(RESULT_DATE, ParseUtils.parseHttpDate("Tue, 2 Jan 2024 12:34:56 GMT"));
+    assertEquals(RESULT_DATE, ParseUtils.parseHttpDate("Tue, 2 Jan 2024 12:34:56 GMT"));
     assertEquals(RESULT_DATE, ParseUtils.parseHttpDate("Tue, 02 Jan 2024 13:34:56 +0100"));
   }
 

--- a/src/test/java/io/vertx/tests/impl/ParseUtilsTest.java
+++ b/src/test/java/io/vertx/tests/impl/ParseUtilsTest.java
@@ -1,5 +1,7 @@
-package io.vertx.httpproxy.impl;
+package io.vertx.tests.impl;
 
+import io.vertx.httpproxy.impl.ParseUtils;
+import junit.framework.TestCase;
 import org.junit.Test;
 
 import java.time.Instant;
@@ -18,7 +20,7 @@ public class ParseUtilsTest {
    */
   @Test
   public void testParseHttpDateRFC_1123_DATE_TIME() throws Exception {
-    assertEquals(RESULT_DATE, ParseUtils.parseHttpDate("Tue, 2 Jan 2024 12:34:56 GMT"));
+    TestCase.assertEquals(RESULT_DATE, ParseUtils.parseHttpDate("Tue, 2 Jan 2024 12:34:56 GMT"));
     assertEquals(RESULT_DATE, ParseUtils.parseHttpDate("Tue, 02 Jan 2024 13:34:56 +0100"));
   }
 

--- a/src/test/java/io/vertx/tests/parsing/ParseTest.java
+++ b/src/test/java/io/vertx/tests/parsing/ParseTest.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
-package io.vertx.httpproxy.parsing;
+package io.vertx.tests.parsing;
 
 import io.vertx.httpproxy.impl.CacheControl;
 import org.junit.Assert;

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -1,0 +1,6 @@
+open module io.vertx.tests {
+  requires io.vertx.httpproxy;
+  requires io.vertx.testing.unit;
+  requires junit;
+  requires wiremock.standalone;
+}


### PR DESCRIPTION
Commits are separate to show the upgrade process and can be cherry picked

1. avoid split package between src/main and src/test
2. avoid using other module impl packages
3. introduce module-info descriptors and bump adjust dependencies to be compatible with JPMS