### PR TITLE
proxy httpclient does not release connection pool when frontend close chunked response

### DIFF
--- a/src/test/java/io/vertx/tests/ProxyClientKeepAliveTest.java
+++ b/src/test/java/io/vertx/tests/ProxyClientKeepAliveTest.java
@@ -266,7 +266,7 @@ public class ProxyClientKeepAliveTest extends ProxyTestBase {
 
   @Test
   public void testFrontendCloseChunkedResponse(TestContext ctx) {
-    testBackendCloseResponse(ctx, true);
+    testFrontendCloseResponse(ctx, true);
   }
 
   private void testFrontendCloseResponse(TestContext ctx, boolean chunked) {
@@ -279,13 +279,11 @@ public class ProxyClientKeepAliveTest extends ProxyTestBase {
         resp.putHeader("content-length", "10000");
       }
       resp.write("part");
-      resp.exceptionHandler(err -> {
-        async.complete();
-      });
+      resp.closeHandler(unused -> async.complete());
     });
     startProxy(backend);
     client = vertx.createHttpClient();
-    client.request(GET, 8081, "localhost", "/").onComplete(ctx.asyncAssertSuccess(req -> {
+    client.request(GET, 8080, "localhost", "/").onComplete(ctx.asyncAssertSuccess(req -> {
       req.send().onComplete(ctx.asyncAssertSuccess(resp -> {
         resp.handler(buff -> {
           resp.request().connection().close();


### PR DESCRIPTION

proxy httpclient does not release connection pool when frontend close chunked response

