### PR TITLE
Apply interceptors for WebSocket handshake

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -120,6 +120,8 @@ Likewise with the proxy response
 {@link examples.HttpProxyExamples#outboundInterceptor}
 ----
 
+Interceptors will not apply to WebSocket handshake packets by default. While in some use cases (e.g. changing the WebSocket request path), you can overwrite {@link io.vertx.httpproxy.ProxyInterceptor#allowApplyToWebSocket} method to allow interceptors apply to WebSocket.
+
 ==== Body filtering
 
 You can filter body by simply replacing the original {@link io.vertx.httpproxy.Body} with a new one
@@ -173,4 +175,13 @@ You can use body interceptor to create body transformations for common data type
 ----
 
 Please check the {@link io.vertx.httpproxy.interceptors.BodyTransformer} for other supported transformations.
+
+==== WebSocket interceptor
+
+You can use WebSocket interceptor to wrap a interceptor to let it allow WebSocket handling:
+
+[source,java]
+----
+{@link examples.HttpProxyExamples#webSocketInterceptorPath}
+----
 

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -178,7 +178,7 @@ Please check the {@link io.vertx.httpproxy.interceptors.BodyTransformer} for oth
 
 ==== WebSocket interceptor
 
-You can use WebSocket interceptor to wrap a interceptor to let it allow WebSocket handling:
+You can use WebSocket interceptor to wrap an interceptor to let it allow WebSocket handling:
 
 [source,java]
 ----

--- a/src/main/java/examples/HttpProxyExamples.java
+++ b/src/main/java/examples/HttpProxyExamples.java
@@ -13,10 +13,7 @@ import io.vertx.core.net.HostAndPort;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.httpproxy.*;
 import io.vertx.httpproxy.cache.CacheOptions;
-import io.vertx.httpproxy.interceptors.BodyInterceptor;
-import io.vertx.httpproxy.interceptors.BodyTransformer;
-import io.vertx.httpproxy.interceptors.HeadersInterceptor;
-import io.vertx.httpproxy.interceptors.QueryInterceptor;
+import io.vertx.httpproxy.interceptors.*;
 
 import java.util.Set;
 
@@ -127,6 +124,12 @@ public class HttpProxyExamples {
           jsonObject -> removeSomeFields(jsonObject)
         )
       ));
+  }
+
+  public void webSocketInterceptorPath(HttpProxy proxy) {
+    proxy.addInterceptor(
+      WebSocketInterceptor.allow(PathInterceptor.addPrefix("/api"))
+    );
   }
 
   public void immediateResponse(HttpProxy proxy) {

--- a/src/main/java/io/vertx/httpproxy/ProxyContext.java
+++ b/src/main/java/io/vertx/httpproxy/ProxyContext.java
@@ -30,6 +30,11 @@ public interface ProxyContext {
   Future<Void> sendResponse();
 
   /**
+   * @return if this request or response is the handshake of WebSocket
+   */
+  boolean isWebSocket();
+
+  /**
    * Attach a payload to the context
    *
    * @param name the payload name

--- a/src/main/java/io/vertx/httpproxy/ProxyInterceptor.java
+++ b/src/main/java/io/vertx/httpproxy/ProxyInterceptor.java
@@ -28,4 +28,13 @@ public interface ProxyInterceptor {
   default Future<Void> handleProxyResponse(ProxyContext context) {
     return context.sendResponse();
   }
+
+  /**
+   * Used to set whether to apply the interceptor to the WebSocket
+   * handshake packet. The default value is false.
+   * @return the boolean value
+   */
+  default boolean allowApplyToWebSocket() {
+    return false;
+  }
 }

--- a/src/main/java/io/vertx/httpproxy/ProxyResponse.java
+++ b/src/main/java/io/vertx/httpproxy/ProxyResponse.java
@@ -16,6 +16,10 @@ import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.streams.ReadStream;
 
 import java.util.function.Function;
@@ -107,6 +111,11 @@ public interface ProxyResponse {
    */
   @Fluent
   ProxyResponse setBody(Body body);
+
+  /**
+   * @return the proxied HTTP server response
+   */
+  HttpClientResponse proxiedResponse();
 
   boolean publicCacheControl();
 

--- a/src/main/java/io/vertx/httpproxy/impl/ProxiedResponse.java
+++ b/src/main/java/io/vertx/httpproxy/impl/ProxiedResponse.java
@@ -135,6 +135,11 @@ class ProxiedResponse implements ProxyResponse {
   }
 
   @Override
+  public HttpClientResponse proxiedResponse() {
+    return response;
+  }
+
+  @Override
   public boolean publicCacheControl() {
     return publicCacheControl;
   }

--- a/src/main/java/io/vertx/httpproxy/impl/ReverseProxy.java
+++ b/src/main/java/io/vertx/httpproxy/impl/ReverseProxy.java
@@ -133,6 +133,9 @@ public class ReverseProxy implements HttpProxy {
     public Future<ProxyResponse> sendRequest() {
       if (filters.hasNext()) {
         ProxyInterceptor next = filters.next();
+        if (isWebSocket && !next.allowApplyToWebSocket()) {
+          return sendRequest();
+        }
         return next.handleProxyRequest(this);
       } else {
         if (isWebSocket) {
@@ -162,6 +165,9 @@ public class ReverseProxy implements HttpProxy {
     public Future<Void> sendResponse() {
       if (filters.hasPrevious()) {
         ProxyInterceptor filter = filters.previous();
+        if (isWebSocket && !filter.allowApplyToWebSocket()) {
+          return sendResponse();
+        }
         return filter.handleProxyResponse(this);
       } else {
         if (isWebSocket) {

--- a/src/main/java/io/vertx/httpproxy/interceptors/WebSocketInterceptor.java
+++ b/src/main/java/io/vertx/httpproxy/interceptors/WebSocketInterceptor.java
@@ -1,0 +1,24 @@
+package io.vertx.httpproxy.interceptors;
+
+import io.vertx.codegen.annotations.Unstable;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.httpproxy.ProxyInterceptor;
+import io.vertx.httpproxy.interceptors.impl.WebSocketInterceptorImpl;
+
+/**
+ * Interceptor settings for WebSocket.
+ */
+@Unstable
+@VertxGen
+public interface WebSocketInterceptor {
+
+  /**
+   * A wrapper to allow interceptor apply to WebSocket handshake packages.
+   *
+   * @param interceptor the original interceptor
+   * @return the generated interceptor
+   */
+  static ProxyInterceptor allow(ProxyInterceptor interceptor) {
+    return new WebSocketInterceptorImpl(interceptor);
+  }
+}

--- a/src/main/java/io/vertx/httpproxy/interceptors/impl/BodyInterceptorImpl.java
+++ b/src/main/java/io/vertx/httpproxy/interceptors/impl/BodyInterceptorImpl.java
@@ -35,8 +35,6 @@ public class BodyInterceptorImpl implements ProxyInterceptor {
 
   @Override
   public Future<ProxyResponse> handleProxyRequest(ProxyContext context) {
-    if (context.isWebSocket()) return context.sendRequest();
-
     Body body = context.request().getBody();
     BufferingWriteStream bws = new BufferingWriteStream();
     return body.stream().pipeTo(bws).compose(r -> {
@@ -48,8 +46,6 @@ public class BodyInterceptorImpl implements ProxyInterceptor {
 
   @Override
   public Future<Void> handleProxyResponse(ProxyContext context) {
-    if (context.isWebSocket()) return context.sendResponse();
-
     Body body = context.response().getBody();
     BufferingWriteStream bws = new BufferingWriteStream();
     return body.stream().pipeTo(bws).compose(r -> {

--- a/src/main/java/io/vertx/httpproxy/interceptors/impl/BodyInterceptorImpl.java
+++ b/src/main/java/io/vertx/httpproxy/interceptors/impl/BodyInterceptorImpl.java
@@ -35,6 +35,8 @@ public class BodyInterceptorImpl implements ProxyInterceptor {
 
   @Override
   public Future<ProxyResponse> handleProxyRequest(ProxyContext context) {
+    if (context.isWebSocket()) return context.sendRequest();
+
     Body body = context.request().getBody();
     BufferingWriteStream bws = new BufferingWriteStream();
     return body.stream().pipeTo(bws).compose(r -> {
@@ -46,6 +48,8 @@ public class BodyInterceptorImpl implements ProxyInterceptor {
 
   @Override
   public Future<Void> handleProxyResponse(ProxyContext context) {
+    if (context.isWebSocket()) return context.sendResponse();
+
     Body body = context.response().getBody();
     BufferingWriteStream bws = new BufferingWriteStream();
     return body.stream().pipeTo(bws).compose(r -> {

--- a/src/main/java/io/vertx/httpproxy/interceptors/impl/WebSocketInterceptorImpl.java
+++ b/src/main/java/io/vertx/httpproxy/interceptors/impl/WebSocketInterceptorImpl.java
@@ -6,7 +6,7 @@ import io.vertx.httpproxy.ProxyInterceptor;
 import io.vertx.httpproxy.ProxyResponse;
 
 public class WebSocketInterceptorImpl implements ProxyInterceptor {
-  ProxyInterceptor interceptor;
+  private final ProxyInterceptor interceptor;
 
   public WebSocketInterceptorImpl(ProxyInterceptor interceptor) {
     this.interceptor = interceptor;

--- a/src/main/java/io/vertx/httpproxy/interceptors/impl/WebSocketInterceptorImpl.java
+++ b/src/main/java/io/vertx/httpproxy/interceptors/impl/WebSocketInterceptorImpl.java
@@ -1,0 +1,29 @@
+package io.vertx.httpproxy.interceptors.impl;
+
+import io.vertx.core.Future;
+import io.vertx.httpproxy.ProxyContext;
+import io.vertx.httpproxy.ProxyInterceptor;
+import io.vertx.httpproxy.ProxyResponse;
+
+public class WebSocketInterceptorImpl implements ProxyInterceptor {
+  ProxyInterceptor interceptor;
+
+  public WebSocketInterceptorImpl(ProxyInterceptor interceptor) {
+    this.interceptor = interceptor;
+  }
+
+  @Override
+  public Future<ProxyResponse> handleProxyRequest(ProxyContext context) {
+    return interceptor.handleProxyRequest(context);
+  }
+
+  @Override
+  public Future<Void> handleProxyResponse(ProxyContext context) {
+    return interceptor.handleProxyResponse(context);
+  }
+
+  @Override
+  public boolean allowApplyToWebSocket() {
+    return true;
+  }
+}

--- a/src/test/java/io/vertx/tests/WebSocketCacheTest.java
+++ b/src/test/java/io/vertx/tests/WebSocketCacheTest.java
@@ -1,0 +1,47 @@
+package io.vertx.tests;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.httpproxy.ProxyOptions;
+import io.vertx.httpproxy.cache.CacheOptions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class WebSocketCacheTest extends ProxyTestBase {
+
+  public WebSocketCacheTest() {
+    super(new ProxyOptions().setCacheOptions(new CacheOptions()));
+  }
+
+  @Test
+  public void testWsWithCache(TestContext ctx) {
+    Async latch = ctx.async();
+    SocketAddress backend = startHttpBackend(ctx, 8081, req -> {
+      req.toWebSocket().onSuccess(ws -> {
+        ws.handler(ws::write);
+      });
+    });
+    startProxy(backend);
+    vertx.createWebSocketClient().connect(8080, "localhost", "/").onComplete(ctx.asyncAssertSuccess(ws1 -> {
+      ws1.handler(buffer -> {
+        ctx.assertEquals(buffer.toString(), "v1");
+        ws1.close().onComplete(ctx.asyncAssertSuccess(v -> {
+          vertx.createWebSocketClient().connect(8080, "localhost", "/").onComplete(ctx.asyncAssertSuccess(ws2 -> {
+            ws2.handler(buffer2 -> {
+              ctx.assertEquals(buffer2.toString(), "v2");
+              ws2.close().onComplete(ctx.asyncAssertSuccess(v2 -> {
+                latch.complete();
+              }));
+            });
+            ws2.write(Buffer.buffer("v2"));
+          }));
+        }));
+      });
+      ws1.write(Buffer.buffer("v1"));
+    }));
+  }
+}

--- a/src/test/java/io/vertx/tests/WebSocketCacheTest.java
+++ b/src/test/java/io/vertx/tests/WebSocketCacheTest.java
@@ -37,11 +37,11 @@ public class WebSocketCacheTest extends ProxyTestBase {
                 latch.complete();
               }));
             });
-            ws2.write(Buffer.buffer("v2"));
+            ws2.write(Buffer.buffer("v2")); // second WebSocket, send and reply "v2"
           }));
         }));
       });
-      ws1.write(Buffer.buffer("v1"));
+      ws1.write(Buffer.buffer("v1")); // first WebSocket, send and reply "v1"
     }));
   }
 }

--- a/src/test/java/io/vertx/tests/interceptors/WebSocketInterceptorTest.java
+++ b/src/test/java/io/vertx/tests/interceptors/WebSocketInterceptorTest.java
@@ -40,6 +40,14 @@ public class WebSocketInterceptorTest extends ProxyTestBase {
     });
   }
 
+  /**
+   * The interceptor adds a suffix to the uri. If uri is changed by the interceptor, it calls a hit.
+   *
+   * @param ctx the test context
+   * @param interceptor the added interceptor
+   * @param httpHit if interceptor changes the regular HTTP packet
+   * @param wsHit if interceptor changes the WebSocket packet
+   */
   private void testWithInterceptor(TestContext ctx, ProxyInterceptor interceptor, boolean httpHit, boolean wsHit) {
     Async latch = ctx.async(4);
     SocketAddress backend = backend(ctx, latch);
@@ -77,18 +85,21 @@ public class WebSocketInterceptorTest extends ProxyTestBase {
 
   @Test
   public void testNotApplySocket(TestContext ctx) {
+    // this interceptor only applies to regular HTTP traffic
     ProxyInterceptor interceptor = PathInterceptor.changePath(x -> x + "/updated");
     testWithInterceptor(ctx, interceptor, true, false);
   }
 
   @Test
   public void testWithSocketInterceptor(TestContext ctx) {
+    // this interceptor applies to both regular HTTP traffic and WebSocket handshake
     ProxyInterceptor interceptor = WebSocketInterceptor.allow(PathInterceptor.changePath(x -> x + "/updated"));
     testWithInterceptor(ctx, interceptor, true, true);
   }
 
   @Test
   public void testOnlyHitSocket(TestContext ctx) {
+    // this interceptor only applies to WebSocket handshake
     ProxyInterceptor interceptor = new ProxyInterceptor() {
       @Override
       public Future<ProxyResponse> handleProxyRequest(ProxyContext context) {

--- a/src/test/java/io/vertx/tests/interceptors/WebSocketInterceptorTest.java
+++ b/src/test/java/io/vertx/tests/interceptors/WebSocketInterceptorTest.java
@@ -1,0 +1,110 @@
+package io.vertx.tests.interceptors;
+
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.httpproxy.*;
+import io.vertx.httpproxy.interceptors.PathInterceptor;
+import io.vertx.httpproxy.interceptors.WebSocketInterceptor;
+import io.vertx.tests.ProxyTestBase;
+import org.junit.Test;
+
+
+
+public class WebSocketInterceptorTest extends ProxyTestBase {
+
+  public WebSocketInterceptorTest(ProxyOptions options) {
+    super(options);
+  }
+
+  private SocketAddress backend(TestContext ctx, Async async) {
+    return startHttpBackend(ctx, 8081, req -> {
+      if (req.uri().startsWith("/ws")) {
+        Future<ServerWebSocket> fut = req.toWebSocket();
+        fut.onComplete(ctx.asyncAssertSuccess(ws -> {
+          ws.handler(buff -> {
+            ws.write(Buffer.buffer(req.uri()));
+          });
+          ws.closeHandler(v -> {
+            async.countDown();
+          });
+        }));
+      } else {
+        req.response().end(req.uri()).onComplete(v -> async.countDown());
+      }
+    });
+  }
+
+  private void testWithInterceptor(TestContext ctx, ProxyInterceptor interceptor, boolean httpHit, boolean wsHit) {
+    Async latch = ctx.async(4);
+    SocketAddress backend = backend(ctx, latch);
+
+    startProxy(proxy -> {
+      proxy.origin(backend);
+      if (interceptor != null) proxy.addInterceptor(interceptor);
+    });
+
+    vertx.createHttpClient().request(HttpMethod.GET, 8080, "localhost", "/http")
+      .compose(HttpClientRequest::send)
+      .onComplete(ctx.asyncAssertSuccess(resp -> {
+        resp.body().onSuccess(body -> {
+          ctx.assertEquals(body.toString().endsWith("/updated"), httpHit);
+          latch.countDown();
+
+          vertx.createWebSocketClient().connect(8080, "localhost", "/ws")
+            .onComplete(ctx.asyncAssertSuccess(webSocket -> {
+              webSocket.handler(buffer -> {
+                ctx.assertEquals(buffer.toString().endsWith("/updated"), wsHit);
+                latch.countDown();
+                webSocket.close();
+              });
+              webSocket.write(Buffer.buffer("hello"));
+            }));
+        });
+      }));
+    latch.await(5000);
+  }
+
+  @Test
+  public void testNotInterceptor(TestContext ctx) {
+    testWithInterceptor(ctx, null, false, false);
+  }
+
+  @Test
+  public void testNotApplySocket(TestContext ctx) {
+    ProxyInterceptor interceptor = PathInterceptor.changePath(x -> x + "/updated");
+    testWithInterceptor(ctx, interceptor, true, false);
+  }
+
+  @Test
+  public void testWithSocketInterceptor(TestContext ctx) {
+    ProxyInterceptor interceptor = WebSocketInterceptor.allow(PathInterceptor.changePath(x -> x + "/updated"));
+    testWithInterceptor(ctx, interceptor, true, true);
+  }
+
+  @Test
+  public void testOnlyHitSocket(TestContext ctx) {
+    ProxyInterceptor interceptor = new ProxyInterceptor() {
+      @Override
+      public Future<ProxyResponse> handleProxyRequest(ProxyContext context) {
+        if (context.isWebSocket()) {
+          context.request().setURI(context.request().getURI() + "/updated");
+        }
+        return context.sendRequest();
+      }
+
+      @Override
+      public boolean allowApplyToWebSocket() {
+        return true;
+      }
+    };
+    testWithInterceptor(ctx, interceptor, false, true);
+  }
+
+
+}


### PR DESCRIPTION
Should close #48.

Now interceptor can be applied to WebSocket handshake packets. Since most interceptors should not modify packets during the WebSocket establishment, they are not applied by default. They can be used by overwriting `allowApplyToWebSocket()` method or wrapping with `WebSocketInterceptor.allow()` method.