### PR TITLE
Fix testFrontendCloseChunkedResponse

### DIFF
--- a/src/test/java/io/vertx/tests/ProxyClientKeepAliveTest.java
+++ b/src/test/java/io/vertx/tests/ProxyClientKeepAliveTest.java
@@ -266,7 +266,7 @@ public class ProxyClientKeepAliveTest extends ProxyTestBase {
 
   @Test
   public void testFrontendCloseChunkedResponse(TestContext ctx) {
-    testBackendCloseResponse(ctx, true);
+    testFrontendCloseResponse(ctx, true);
   }
 
   private void testFrontendCloseResponse(TestContext ctx, boolean chunked) {


### PR DESCRIPTION
It was calling the wrong common test method.