### PR TITLE
Fix #85

### DIFF
--- a/src/main/java/io/vertx/httpproxy/impl/ProxiedRequest.java
+++ b/src/main/java/io/vertx/httpproxy/impl/ProxiedRequest.java
@@ -72,7 +72,7 @@ public class ProxiedRequest implements ProxyRequest {
     this.absoluteURI = proxiedRequest.absoluteURI();
     this.proxiedRequest = proxiedRequest;
     this.context = (ContextInternal) ((HttpServerRequestInternal) proxiedRequest).context();
-    this.authority = proxiedRequest.authority();
+    this.authority = null; // null is used as a signal to indicate an unchanged authority
   }
 
   @Override
@@ -164,7 +164,7 @@ public class ProxiedRequest implements ProxyRequest {
     for (Map.Entry<String, String> header : headers) {
       String name = header.getKey();
       String value = header.getValue();
-      if (!HOP_BY_HOP_HEADERS.contains(name) && !name.equalsIgnoreCase("host")) {
+      if (!HOP_BY_HOP_HEADERS.contains(name) && !name.equalsIgnoreCase(HttpHeaders.HOST.toString())) {
         request.headers().add(name, value);
       }
     }

--- a/src/main/java/io/vertx/httpproxy/impl/ProxiedRequest.java
+++ b/src/main/java/io/vertx/httpproxy/impl/ProxiedRequest.java
@@ -105,7 +105,7 @@ public class ProxiedRequest implements ProxyRequest {
   @Override
   public ProxyRequest setAuthority(HostAndPort authority) {
     Objects.requireNonNull(authority);
-    this.authority= authority;
+    this.authority = authority;
     return this;
   }
 
@@ -155,7 +155,6 @@ public class ProxiedRequest implements ProxyRequest {
       r.pause(); // Pause it
       return new ProxiedResponse(this, proxiedRequest.response(), r);
     }).onComplete(responseHandler);
-
 
     request.setMethod(method);
     request.setURI(uri);

--- a/src/test/java/io/vertx/httpproxy/ProxyClientKeepAliveTest.java
+++ b/src/test/java/io/vertx/httpproxy/ProxyClientKeepAliveTest.java
@@ -383,7 +383,7 @@ public class ProxyClientKeepAliveTest extends ProxyTestBase {
     startProxy(backend);
     HttpClient client = vertx.createHttpClient(new HttpClientOptions().setProtocolVersion(version));
     StringBuilder sb = new StringBuilder();
-    for (int i = 0;i < num;i++) {
+    for (int i = 0; i < num; i++) {
       sb.append("chunk-").append(i);
     }
     client.request(GET, 8080, "localhost", "/", ctx.asyncAssertSuccess(req -> {
@@ -417,7 +417,7 @@ public class ProxyClientKeepAliveTest extends ProxyTestBase {
     Async latch = ctx.async();
     SocketAddress backend = startHttpBackend(ctx, 8081, req -> {
       StringBuilder sb = new StringBuilder();
-      for (int i = 0;i < num;i++) {
+      for (int i = 0; i < num; i++) {
         sb.append("chunk-").append(i);
       }
       ctx.assertEquals("chunked", req.getHeader("transfer-encoding"));
@@ -701,8 +701,8 @@ public class ProxyClientKeepAliveTest extends ProxyTestBase {
   private StringBuilder randomAlphaString(int len) {
     Random random = new Random();
     StringBuilder uri = new StringBuilder();
-    for (int i = 0;i < len;i++) {
-      uri.append((char)('A' + random.nextInt(26)));
+    for (int i = 0; i < len; i++) {
+      uri.append((char) ('A' + random.nextInt(26)));
     }
     return uri;
   }

--- a/src/test/java/io/vertx/httpproxy/ProxyRequestTest.java
+++ b/src/test/java/io/vertx/httpproxy/ProxyRequestTest.java
@@ -646,8 +646,8 @@ public class ProxyRequestTest extends ProxyTestBase {
 
   static {
     byte[] bytes = new byte[1024];
-    for (int i = 0;i < 1024;i++) {
-      bytes[i] = (byte)('A' + (i % 26));
+    for (int i = 0; i < 1024; i++) {
+      bytes[i] = (byte) ('A' + (i % 26));
     }
     CHUNK = Buffer.buffer(bytes);
   }
@@ -666,8 +666,8 @@ public class ProxyRequestTest extends ProxyTestBase {
       stream.handler(buff -> {
         if (dataHandler != null) {
           byte[] bytes = new byte[buff.length()];
-          for (int i = 0;i < bytes.length;i++) {
-            bytes[i] = (byte)(('a' - 'A') + buff.getByte(i));
+          for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte) (('a' - 'A') + buff.getByte(i));
           }
           expected.appendBytes(bytes);
           dataHandler.handle(Buffer.buffer(bytes));

--- a/src/test/java/io/vertx/httpproxy/ProxyRequestTest.java
+++ b/src/test/java/io/vertx/httpproxy/ProxyRequestTest.java
@@ -448,7 +448,7 @@ public class ProxyRequestTest extends ProxyTestBase {
   @Test
   public void testUpdateRequestHeaders(TestContext ctx) throws Exception {
     SocketAddress backend = startHttpBackend(ctx, 8081, req -> {
-      ctx.assertNotEquals("example.org", req.getHeader("Host"));
+      ctx.assertNotEquals("example.org", req.getHeader(HttpHeaders.HOST));
       ctx.assertNull(req.getHeader("header"));
       ctx.assertEquals("proxy_header_value", req.getHeader("proxy_header"));
       req.response().putHeader("header", "header_value").end();
@@ -457,7 +457,6 @@ public class ProxyRequestTest extends ProxyTestBase {
     startHttpServer(ctx, serverOptions, req -> {
       ProxyRequest proxyReq = ProxyRequest.reverseProxy(req);
       MultiMap clientHeaders = proxyReq.headers();
-      clientHeaders.add("Host", "example.org");
       clientHeaders.add("proxy_header", "proxy_header_value");
       ctx.assertEquals("header_value", clientHeaders.get("header"));
       clientHeaders.remove("header");
@@ -476,6 +475,7 @@ public class ProxyRequestTest extends ProxyTestBase {
         .compose(req ->
       req
           .putHeader("header", "header_value")
+          .putHeader(HttpHeaders.HOST, "example.org")
           .send()
           .compose(resp -> {
             ctx.assertEquals("proxy_header_value", resp.getHeader("proxy_header"));


### PR DESCRIPTION
Fixes https://github.com/eclipse-vertx/vertx-http-proxy/issues/85

`null` is used as a signal, so we should not set a default in the constructor. 

https://github.com/fbuetler/vertx-http-proxy/blob/a97630bc9ee465f073fbefd5febbe12cdc43d78b/src/main/java/io/vertx/httpproxy/impl/ProxiedRequest.java#L173

With this, the updated reproducer provided in the issue passes.