### PR TITLE
Introduce OriginRequestProvider

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -48,16 +48,16 @@ All user-agent requests are forwarded to the *origin server* conveniently.
 
 === Origin server routing
 
-You can create a proxy that forwards all the traffic to a single server like seen before
+You can create a proxy that forwards all the traffic to a single server like seen before.
 
-You can set an origin selector to route the traffic to a given server
+You can set an origin selector to route the traffic to a given server:
 
 [source,java]
 ----
 {@link examples.HttpProxyExamples#originSelector}
 ----
 
-You can set a function to create the client request to the origin server for ultimate flexibility
+You can set a function to create the client request to the origin server for ultimate flexibility:
 
 [source,java]
 ----

--- a/src/main/java/io/vertx/httpproxy/OriginRequestProvider.java
+++ b/src/main/java/io/vertx/httpproxy/OriginRequestProvider.java
@@ -1,0 +1,56 @@
+package io.vertx.httpproxy;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.core.net.SocketAddress;
+
+import java.util.function.Function;
+
+/**
+ * A provider that creates the request to the <i><b>origin</b></i> server based on {@link ProxyContext}.
+ */
+@VertxGen
+@FunctionalInterface
+public interface OriginRequestProvider {
+
+  /**
+   * Creates a simple provider for a fixed {@code port} and {@code host}.
+   */
+  static OriginRequestProvider fixedAddress(int port, String host) {
+    return fixedAddress(SocketAddress.inetSocketAddress(port, host));
+  }
+
+  /**
+   * Creates a simple provider for a fixed {@link SocketAddress}.
+   */
+  static OriginRequestProvider fixedAddress(SocketAddress address) {
+    return new OriginRequestProvider() {
+      @Override
+      public Future<HttpClientRequest> create(ProxyContext proxyContext) {
+        return proxyContext.client().request(new RequestOptions().setServer(address));
+      }
+    };
+  }
+
+  /**
+   * Creates a provider that selects the <i><b>origin</b></i> server based on {@link ProxyContext}.
+   */
+  static OriginRequestProvider selector(Function<ProxyContext, Future<SocketAddress>> selector) {
+    return new OriginRequestProvider() {
+      @Override
+      public Future<HttpClientRequest> create(ProxyContext proxyContext) {
+        return selector.apply(proxyContext).flatMap(server -> proxyContext.client().request(new RequestOptions().setServer(server)));
+      }
+    };
+  }
+
+  /**
+   * Create the {@link HttpClientRequest} to the origin server for a given {@link ProxyContext}.
+   *
+   * @param proxyContext the context of the proxied request and response
+   * @return a future, completed with the {@link HttpClientRequest} or failed
+   */
+  Future<HttpClientRequest> create(ProxyContext proxyContext);
+}

--- a/src/main/java/io/vertx/httpproxy/ProxyContext.java
+++ b/src/main/java/io/vertx/httpproxy/ProxyContext.java
@@ -2,6 +2,7 @@ package io.vertx.httpproxy;
 
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
+import io.vertx.core.http.HttpClient;
 
 /**
  * A controller for proxy interception.
@@ -50,4 +51,9 @@ public interface ProxyContext {
    * @return the attached payload
    */
   <T> T get(String name, Class<T> type);
+
+  /**
+   * @return the {@link HttpClient} use to interact with the origin server
+   */
+  HttpClient client();
 }


### PR DESCRIPTION
Closes #35, closes #44
    
`OriginRequestProvider` is a Vert.x API type that unifies all the origin selection methods currently present as overloaded methods in `HttpProxy`.
    
`OriginRequestProvider` being a `@FunctionalInterface`, users can provide one in the form of a lambda.
    
`OriginRequestProvider` is a little different from the existing contract.
Instead of the proxied request and HTTP client as parameters, it has the `ProxyContext` (that exposes all the proxy data and the client).
    
This allows implementations to make a decision on the modifications interceptors can make (including when the request is an upgrade to WebSocket). See #44

It also allows interceptors and providers to exchange data via the `ProxyContext` attachments. See #35
