### PR TITLE
Fix flaky test.

### DIFF
--- a/src/test/java/io/vertx/tests/ProxyRequestTest.java
+++ b/src/test/java/io/vertx/tests/ProxyRequestTest.java
@@ -538,7 +538,8 @@ public class ProxyRequestTest extends ProxyTestBase {
       full.whenComplete((v, err) -> {
         proxyReq.release();
         proxyReq.setBody(Body.body(Buffer.buffer("another-request")));
-        backendClient.request(new RequestOptions().setServer(backend)).onComplete(ctx.asyncAssertSuccess(clientReq -> {
+        backendClient.request(new RequestOptions().setServer(backend))
+          .onComplete(ctx.asyncAssertSuccess(clientReq -> {
           proxyReq.send(clientReq).onComplete(ctx.asyncAssertSuccess(proxyResp -> {
             proxyResp.send().onComplete(ctx.asyncAssertSuccess());
           }));
@@ -546,30 +547,26 @@ public class ProxyRequestTest extends ProxyTestBase {
       });
     });
     httpClient = vertx.createHttpClient();
-    Async drainedLatch = ctx.async();
     Buffer chunk = Buffer.buffer(new byte[1024]);
-    httpClient.request(HttpMethod.GET, 8080, "localhost", "/somepath").onComplete(ctx.asyncAssertSuccess(req -> {
-      req.setChunked(true);
-      req.putHeader("header", "header-value");
-      vertx.setPeriodic(1, id -> {
-        if (req.writeQueueFull()) {
-          req.drainHandler(v1 -> {
-            req.end().onSuccess(v2 -> {
-              vertx.cancelTimer(id);
-              drainedLatch.complete();
-            });
-          });
-          full.complete(null);
-        } else {
-          req.write(chunk);
-        }
-      });
-      req.response().onComplete(ctx.asyncAssertSuccess(resp -> {
-        resp.body().onComplete(ctx.asyncAssertSuccess(body -> {
-          ctx.assertEquals("another-request", body.toString());
-        }));
-      }));
-    }));
+    Buffer body = httpClient
+      .request(HttpMethod.GET, 8080, "localhost", "/somepath")
+      .compose(req -> {
+        req.setChunked(true);
+        req.putHeader("header", "header-value");
+        vertx.setPeriodic(1, id -> {
+          if (req.writeQueueFull()) {
+            vertx.cancelTimer(id);
+            req.end().onComplete(ctx.asyncAssertSuccess());
+            full.complete(null);
+          } else {
+            req.write(chunk);
+          }
+        });
+        return req.response()
+          .expecting(HttpResponseExpectation.SC_OK)
+          .compose(HttpClientResponse::body);
+      }).await();
+    assertEquals("another-request", body.toString());
   }
 
   @Test


### PR DESCRIPTION
Motivation:

ProxyRequestTest#testReleaseProxyResponse relies on a drain handler to progress, the drain handler is not invoked in a flaky way.

This drain handler is not necessary to make the test progress, hence I'm removing it from the test.

It is not clear whether the issue lies in the test or in the implementation.
